### PR TITLE
Fix primitiveArrayBecomeOneWayNoCopyHash

### DIFF
--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -390,7 +390,8 @@ Object.subclass('Squeak.Primitives',
             case 246: if (this.oldPrims) return this.namedPrimitive('MiscPrimitivePlugin', 'primitiveFindSubstring', argCount);
                 break;  // fail 243-246 if fell through
             // 247: unused
-            case 248: return this.vm.primitiveInvokeObjectAsMethod(argCount, primMethod); // see findSelectorInClass()
+            case 248: if (this.oldPrims) return this.vm.primitiveInvokeObjectAsMethod(argCount, primMethod) // see findSelectorInClass()
+                else return this.primitiveArrayBecome(argCount, false); // one way, opt. copy hash
             case 249: return this.primitiveArrayBecome(argCount, false); // one way, opt. copy hash
             case 254: return this.primitiveVMParameter(argCount);
             //MIDI Primitives (520-539)

--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -157,7 +157,7 @@ Object.subclass('Squeak.Primitives',
             case 69: return this.popNandPushIfOK(argCount+1, this.objectAtPut(false,false,true)); // Method.objectAt:put:
             case 70: return this.popNandPushIfOK(argCount+1, this.instantiateClass(this.stackNonInteger(0), 0)); // Class.new
             case 71: return this.popNandPushIfOK(argCount+1, this.instantiateClass(this.stackNonInteger(1), this.stackPos32BitInt(0))); // Class.new:
-            case 72: return this.primitiveArrayBecome(argCount, false); // one way
+            case 72: return this.primitiveArrayBecome(argCount, false, true); // one way
             case 73: return this.popNandPushIfOK(argCount+1, this.objectAt(false,false,true)); // instVarAt:
             case 74: return this.popNandPushIfOK(argCount+1, this.objectAtPut(false,false,true)); // instVarAt:put:
             case 75: return this.popNandPushIfOK(argCount+1, this.identityHash(this.stackNonInteger(0))); // Object.identityHash
@@ -217,7 +217,7 @@ Object.subclass('Squeak.Primitives',
             case 125: return this.popNandPushIfOK(2, this.setLowSpaceThreshold());
             case 126: return this.primitiveDeferDisplayUpdates(argCount);
             case 127: return this.primitiveShowDisplayRect(argCount);
-            case 128: return this.primitiveArrayBecome(argCount, true); // both ways
+            case 128: return this.primitiveArrayBecome(argCount, true, true); // both ways
             case 129: return this.popNandPushIfOK(1, this.vm.image.specialObjectsArray); //specialObjectsOop
             case 130: return this.primitiveFullGC(argCount);
             case 131: return this.primitivePartialGC(argCount);
@@ -391,8 +391,8 @@ Object.subclass('Squeak.Primitives',
                 break;  // fail 243-246 if fell through
             // 247: unused
             case 248: if (this.oldPrims) return this.vm.primitiveInvokeObjectAsMethod(argCount, primMethod) // see findSelectorInClass()
-                else return this.primitiveArrayBecome(argCount, false); // one way, opt. copy hash
-            case 249: return this.primitiveArrayBecome(argCount, false); // one way, opt. copy hash
+                else return this.primitiveArrayBecome(argCount, false, false); // one way
+            case 249: return this.primitiveArrayBecome(argCount, false, true); // one way, opt. copy hash
             case 254: return this.primitiveVMParameter(argCount);
             //MIDI Primitives (520-539)
             case 521: return this.namedPrimitive('MIDIPlugin', 'primitiveMIDIClosePort', argCount);
@@ -1362,10 +1362,10 @@ Object.subclass('Squeak.Primitives',
         this.vm.executeNewMethod(receiver, methodObj, numArgs, methodObj.methodPrimitiveIndex(), null, null);
         return true;
     },
-    primitiveArrayBecome: function(argCount, doBothWays) {
+    primitiveArrayBecome: function(argCount, doBothWays, copyHash) {
         var rcvr = this.stackNonInteger(argCount),
-            arg = this.stackNonInteger(argCount-1),
-            copyHash = argCount > 1 ? this.stackBoolean(argCount-2) : true;
+            arg = this.stackNonInteger(argCount-1);
+        copyHash &&= argCount > 1 ? this.stackBoolean(argCount-2) : true;
         if (!this.success) return false;
         this.success = this.vm.image.bulkBecome(rcvr.pointers, arg.pointers, doBothWays, copyHash);
         return this.popNIfOK(argCount);

--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -157,7 +157,7 @@ Object.subclass('Squeak.Primitives',
             case 69: return this.popNandPushIfOK(argCount+1, this.objectAtPut(false,false,true)); // Method.objectAt:put:
             case 70: return this.popNandPushIfOK(argCount+1, this.instantiateClass(this.stackNonInteger(0), 0)); // Class.new
             case 71: return this.popNandPushIfOK(argCount+1, this.instantiateClass(this.stackNonInteger(1), this.stackPos32BitInt(0))); // Class.new:
-            case 72: return this.primitiveArrayBecome(argCount, false, true); // one way
+            case 72: return this.primitiveArrayBecome(argCount, false, true); // one way, do copy hash
             case 73: return this.popNandPushIfOK(argCount+1, this.objectAt(false,false,true)); // instVarAt:
             case 74: return this.popNandPushIfOK(argCount+1, this.objectAtPut(false,false,true)); // instVarAt:put:
             case 75: return this.popNandPushIfOK(argCount+1, this.identityHash(this.stackNonInteger(0))); // Object.identityHash
@@ -217,7 +217,7 @@ Object.subclass('Squeak.Primitives',
             case 125: return this.popNandPushIfOK(2, this.setLowSpaceThreshold());
             case 126: return this.primitiveDeferDisplayUpdates(argCount);
             case 127: return this.primitiveShowDisplayRect(argCount);
-            case 128: return this.primitiveArrayBecome(argCount, true, true); // both ways
+            case 128: return this.primitiveArrayBecome(argCount, true, true); // both ways, do copy hash
             case 129: return this.popNandPushIfOK(1, this.vm.image.specialObjectsArray); //specialObjectsOop
             case 130: return this.primitiveFullGC(argCount);
             case 131: return this.primitivePartialGC(argCount);
@@ -391,7 +391,7 @@ Object.subclass('Squeak.Primitives',
                 break;  // fail 243-246 if fell through
             // 247: unused
             case 248: if (this.oldPrims) return this.vm.primitiveInvokeObjectAsMethod(argCount, primMethod) // see findSelectorInClass()
-                else return this.primitiveArrayBecome(argCount, false, false); // one way
+                else return this.primitiveArrayBecome(argCount, false, false); // one way, do not copy hash
             case 249: return this.primitiveArrayBecome(argCount, false, true); // one way, opt. copy hash
             case 254: return this.primitiveVMParameter(argCount);
             //MIDI Primitives (520-539)
@@ -1365,7 +1365,7 @@ Object.subclass('Squeak.Primitives',
     primitiveArrayBecome: function(argCount, doBothWays, copyHash) {
         var rcvr = this.stackNonInteger(argCount),
             arg = this.stackNonInteger(argCount-1);
-        copyHash &&= argCount > 1 ? this.stackBoolean(argCount-2) : true;
+        if (argCount > 1) copyHash = this.stackBoolean(argCount-2);
         if (!this.success) return false;
         this.success = this.vm.image.bulkBecome(rcvr.pointers, arg.pointers, doBothWays, copyHash);
         return this.popNIfOK(argCount);


### PR DESCRIPTION
Complements [VMMaker-dtl.415](http://forum.world.st/VM-Maker-VMMaker-dtl-415-mcz-td5115197.html)/[Collections-eem.885](http://forum.world.st/The-Trunk-Collections-eem-885-mcz-td5115012.html). Since the latter change, `Object >> #becomeForward:` in Squeak 6.0Alpha has been broken in SqueakJS. As a consequence, also other important functionality such as `ByteString >> #at:put:` have not been working correctly.

With this change, primitive 248 (`primitiveArrayBecomeOneWayNoCopyHash`) is fixed again. The relevant logic was already there, just primitive 248 was still coupled to the old `primitiveInvokeObjectAsMethod` which is no longer up to date.

- Before (Squeak Trunk #20134):

  ![image](https://user-images.githubusercontent.com/38782922/104853639-7b65ae00-5902-11eb-869a-28a9a2c202c2.png)

- After:

  ![image](https://user-images.githubusercontent.com/38782922/104853647-7ef93500-5902-11eb-9990-edc079225620.png)

Remaining questions:
- [ ] I could not find any pointer on when old `primitiveInvokeObjectAsMethod` has been used in production for the last time (has it ever been used?). At least, `TestObjectAsMethodsFunction` works fine in Squeak 3.8, but I really did not find any user of the old primitive in the history of Squeak. Is it sure to replace this behavior for all images that use the V3 bytecode set (see the `this.oldPrims` check)?

Thanks a lot to @fniephaus for the very exc{ellent,lusive,iting} introduction to the SqueakJS development! :-)