### PR TITLE
Add missing argument to runImage

### DIFF
--- a/squeak_headless.js
+++ b/squeak_headless.js
@@ -54,7 +54,7 @@ Object.extend(Squeak, {
 });
 
 // Run image by starting interpreter on it
-function runImage(imageData, imageName) {
+function runImage(imageData, imageName, options) {
 
     // Create Squeak image from raw data
     var image = new Squeak.Image(imageName.replace(/\.image$/i, ""));


### PR DESCRIPTION
The argument isn't passed to the method.

Aside: A variable with the same name is declared and therefore issue does not 'show'.