### PR TITLE
Fix popping correct number of arguments

### DIFF
--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -1431,7 +1431,7 @@ Object.subclass('Squeak.Primitives',
         for (var i = 0; i < length; i++)
             rcvr.pointers[i] = arg.pointers[i];
         rcvr.dirty = arg.dirty;
-        this.vm.pop(argCount);
+        this.vm.popN(argCount);
         return true;
     },
     primitiveLoadImageSegment: function(argCount) {
@@ -2031,7 +2031,7 @@ Object.subclass('Squeak.Primitives',
 'time', {
     primitiveRelinquishProcessorForMicroseconds: function(argCount) {
         // we ignore the optional arg
-        this.vm.pop(argCount);
+        this.vm.popN(argCount);
         this.vm.goIdle();        // might switch process, so must be after pop
         return true;
     },


### PR DESCRIPTION
The wrong popping method is used.

Might be because the interpreter and interpreter.proxy have different naming: 'popN' vs 'pop'. Maybe this should be changed (using 'popN' in the proxy as well instead of 'pop'), but it would require quite a few changes in the plugins as well as changes to the VMMaker code probably.
