### PR TITLE
Improve isAssociation() in vm.primitives.js

### DIFF
--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -841,9 +841,9 @@ Object.subclass('Squeak.Primitives',
         }
         return false;
     },
-    isAssociation: function(obj) {
-        return typeof obj !== "number" && obj.pointersSize() == 2;
-    },
+  isAssociation: function(obj) {
+    return obj.sqClass.pointers[0] === this.vm.specialObjects[Squeak.splOb_SchedulerAssociation].sqClass.pointers[0].pointers[0];
+  },
     ensureSmallInt: function(number) {
         if (number === (number|0) && this.vm.canBeSmallInt(number))
             return number;


### PR DESCRIPTION
We have a Global in the special objects array, so we can be rather more specific in isAssociation(). This bit me when marshaling a complex object for use with the JS bridge.