### PR TITLE
SecurityPlugin: Add primitiveGetUntrustedUserDirectory

### DIFF
--- a/dist/squeak_bundle.js
+++ b/dist/squeak_bundle.js
@@ -5438,7 +5438,7 @@
                 case 175: if (this.oldPrims) return this.namedPrimitive('SoundPlugin', 'primitiveSoundPlaySilence', argCount);
                     else return this.popNandPushIfOK(argCount+1, this.behaviorHash(this.stackNonInteger(0)));
                 case 176: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primWaveTableSoundmixSampleCountintostartingAtpan', argCount);
-                    break;  // fail
+                    else return this.popNandPushIfOK(argCount+1, this.vm.image.isSpur ? 0x3FFFFF : 0xFFF); // primitiveMaxIdentityHash
                 case 177: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primFMSoundmixSampleCountintostartingAtpan', argCount);
                     return this.popNandPushIfOK(argCount+1, this.allInstancesOf(this.stackNonInteger(0)));
                 case 178: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primPluckedSoundmixSampleCountintostartingAtpan', argCount);
@@ -9319,6 +9319,7 @@
                 SqueakFFIPrims:         this.findPluginFunctions("ffi_", "", true),
                 SecurityPlugin: {
                     primitiveDisableImageWrite: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveDisableImageWrite", 0),
+                    primitiveGetUntrustedUserDirectory: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveGetUntrustedUserDirectory", "/SqueakJS"),
                 },
                 LocalePlugin: {
                     primitiveTimezoneOffset: this.fakePrimitive.bind(this, "LocalePlugin.primitiveTimezoneOffset", 0),

--- a/dist/squeak_headless_bundle.js
+++ b/dist/squeak_headless_bundle.js
@@ -5435,7 +5435,7 @@ Object.subclass('Squeak.Primitives',
             case 175: if (this.oldPrims) return this.namedPrimitive('SoundPlugin', 'primitiveSoundPlaySilence', argCount);
                 else return this.popNandPushIfOK(argCount+1, this.behaviorHash(this.stackNonInteger(0)));
             case 176: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primWaveTableSoundmixSampleCountintostartingAtpan', argCount);
-                break;  // fail
+                else return this.popNandPushIfOK(argCount+1, this.vm.image.isSpur ? 0x3FFFFF : 0xFFF); // primitiveMaxIdentityHash
             case 177: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primFMSoundmixSampleCountintostartingAtpan', argCount);
                 return this.popNandPushIfOK(argCount+1, this.allInstancesOf(this.stackNonInteger(0)));
             case 178: if (this.oldPrims) return this.namedPrimitive('SoundGenerationPlugin', 'primPluckedSoundmixSampleCountintostartingAtpan', argCount);
@@ -8327,6 +8327,7 @@ Object.extend(Squeak.Primitives.prototype,
             SqueakFFIPrims:         this.findPluginFunctions("ffi_", "", true),
             SecurityPlugin: {
                 primitiveDisableImageWrite: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveDisableImageWrite", 0),
+                primitiveGetUntrustedUserDirectory: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveGetUntrustedUserDirectory", "/SqueakJS"),
             },
             LocalePlugin: {
                 primitiveTimezoneOffset: this.fakePrimitive.bind(this, "LocalePlugin.primitiveTimezoneOffset", 0),

--- a/vm.plugins.js
+++ b/vm.plugins.js
@@ -33,6 +33,7 @@ Object.extend(Squeak.Primitives.prototype,
             SqueakFFIPrims:         this.findPluginFunctions("ffi_", "", true),
             SecurityPlugin: {
                 primitiveDisableImageWrite: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveDisableImageWrite", 0),
+                primitiveGetUntrustedUserDirectory: this.fakePrimitive.bind(this, "SecurityPlugin.primitiveGetUntrustedUserDirectory", "/SqueakJS"),
             },
             LocalePlugin: {
                 primitiveTimezoneOffset: this.fakePrimitive.bind(this, "LocalePlugin.primitiveTimezoneOffset", 0),


### PR DESCRIPTION
This change allows it, for instance, to enable the preference `#startInUntrustedDirectory` in Squeak.

Please explicitly review whether I have rebuilt the bundles correctly. To me, it looks as if the change in the SoundGenerationPlugin has been forgotten to be built via e3673571294da2cf40adf5265ae0106f087cca65.