### PR TITLE
Repair touch event interpretation on Android Firefox.

### DIFF
--- a/squeak.js
+++ b/squeak.js
@@ -185,9 +185,12 @@ function recordModifiers(evt, display) {
     return modifiers;
 }
 
-var canUseMouseOffset = navigator.userAgent.match("AppleWebKit/");
+var canUseMouseOffset = navigator.userAgent.match("AppleWebKit/") === null ? null : true;
 
 function updateMousePos(evt, canvas, display) {
+    if (canUseMouseOffset === null) {
+        canUseMouseOffset = 'offsetX' in evt;
+    }
     var evtX = canUseMouseOffset ? evt.offsetX : evt.layerX,
         evtY = canUseMouseOffset ? evt.offsetY : evt.layerY;
     if (display.cursorCanvas) {

--- a/squeak.js
+++ b/squeak.js
@@ -185,10 +185,13 @@ function recordModifiers(evt, display) {
     return modifiers;
 }
 
-var canUseMouseOffset = navigator.userAgent.match("AppleWebKit/") === null ? null : true;
+var canUseMouseOffset = null;
 
 function updateMousePos(evt, canvas, display) {
     if (canUseMouseOffset === null) {
+        // Per https://caniuse.com/mdn-api_mouseevent_offsetx, essentially all *current*
+        // browsers support `offsetX`/`offsetY`, but it does little harm to fall back to the
+        // older `layerX`/`layerY` for now.
         canUseMouseOffset = 'offsetX' in evt;
     }
     var evtX = canUseMouseOffset ? evt.offsetX : evt.layerX,


### PR DESCRIPTION
This PR fixes a bug using squeak.js.org with current Firefox (98) on Android: when using touch events to simulate mouse interaction, the mouse ends up at 0@0 and never moves away.

Android Firefox (98, probably earlier too) is able to use `offsetX`/`offsetY` in mouse events, despite not having "AppleWebKit" in its user agent string. This patch first tries checking for "AppleWebKit", as before, but if it is not found, delays a decision until later, when the event is checked for an actual `offsetX` field.