### PR TITLE
Support for 61-bit SmallIntegers in 64-bit images

### DIFF
--- a/vm.interpreter.js
+++ b/vm.interpreter.js
@@ -1414,7 +1414,7 @@ Object.subclass('Squeak.Interpreter',
                 this.popNandPush(2, this.primHandler.makeFloat(numResult));
                 return true;
             }
-            if (numResult >= Squeak.MinSmallInt && numResult <= Squeak.MaxSmallInt) {
+            if (this.canBeSmallInt(numResult)) {
                 this.popNandPush(2, numResult);
                 return true;
             }
@@ -1447,29 +1447,29 @@ Object.subclass('Squeak.Interpreter',
         return obj.sqClass;
     },
     canBeSmallInt: function(anInt) {
-        return (anInt >= Squeak.MinSmallInt) && (anInt <= Squeak.MaxSmallInt);
+        return (anInt >= this.image.minSmallInt) && (anInt <= this.image.maxSmallInt);
     },
     isSmallInt: function(object) {
-        return typeof object === "number";
+        return typeof object === "number" || typeof object === "bigint";
     },
     checkSmallInt: function(maybeSmallInt) { // returns an int and sets success
-        if (typeof maybeSmallInt === "number")
+        if (typeof maybeSmallInt === "number" || typeof maybeSmallInt === "bigint")
             return maybeSmallInt;
         this.success = false;
         return 1;
     },
     quickDivide: function(rcvr, arg) { // must only handle exact case
-        if (arg === 0) return Squeak.NonSmallInt;  // fail if divide by zero
+        if (arg === 0) return this.image.nonSmallInt;  // fail if divide by zero
         var result = rcvr / arg | 0;
         if (result * arg === rcvr) return result;
-        return Squeak.NonSmallInt;     // fail if result is not exact
+        return this.image.nonSmallInt;     // fail if result is not exact
     },
     div: function(rcvr, arg) {
-        if (arg === 0) return Squeak.NonSmallInt;  // fail if divide by zero
+        if (arg === 0) return this.image.nonSmallInt;  // fail if divide by zero
         return Math.floor(rcvr/arg);
     },
     mod: function(rcvr, arg) {
-        if (arg === 0) return Squeak.NonSmallInt;  // fail if divide by zero
+        if (arg === 0) return this.image.nonSmallInt;  // fail if divide by zero
         return rcvr - Math.floor(rcvr/arg) * arg;
     },
     safeShift: function(smallInt, shiftCount) {
@@ -1478,11 +1478,11 @@ Object.subclass('Squeak.Interpreter',
             if (shiftCount < -31) return smallInt < 0 ? -1 : 0;
             return smallInt >> -shiftCount; // OK to lose bits shifting right
         }
-        if (shiftCount > 31) return smallInt == 0 ? 0 : Squeak.NonSmallInt;
+        if (shiftCount > 31) return smallInt == 0 ? 0 : this.image.nonSmallInt;
         // check for lost bits by seeing if computation is reversible
         var shifted = smallInt << shiftCount;
         if  ((shifted>>shiftCount) === smallInt) return shifted;
-        return Squeak.NonSmallInt;  //non-small result will cause failure
+        return null;
     },
 },
 'utils',

--- a/vm.js
+++ b/vm.js
@@ -181,6 +181,9 @@ Object.extend(Squeak,
     MinSmallInt: -0x40000000,
     MaxSmallInt:  0x3FFFFFFF,
     NonSmallInt: -0x50000000,           // non-small and neg (so non pos32 too)
+    MinSmallInt64: -0x1000000000000000n,
+    MaxSmallInt64:  0x0FFFFFFFFFFFFFFFn,
+    NonSmallInt64: -0x2000000000000000n, // non-small and neg (so non pos64 too)
     MillisecondClockMask: 0x1FFFFFFF,
 },
 "error codes", {


### PR DESCRIPTION
This is not meant to be merged at the moment but rather to document an open issue. I was confused that when opening 64-bit images in SqueakJS, arithmetic primitives are unable to work with 61-bit numbers as in the OSVM. In this PR, I attempted to fix this by making the relevant constants dynamic depending on the image, but then realized that JS numbers have a smaller value range than Squeak 64-bit SmallIntegers. We could use bigints instead but these require explicit conversions for all arithmetic operations with normal numbers, which would clutter the code base and slow things down.

Thus, the open questions are:

- How significant is the impact on readability of adding support for bigints in arithmetic primitives?
- How significant is the impact on performance of adding support for bigints in arithmetic primitives? (I think it will always be faster than the image-side fallback code path, but the question is how much the conversion/type check will slow down the 31-bit number case.)
- What consequences would there be if SqueakJS continued not to support 61-bit numbers in 64-bit images? Should images be able to deal with that or is that a violation of the contract?

If this feature is not possible or a good idea, maybe this decision should be documented somewhere (such as directly at the constants) before the next person stumbles about this again. :D