### PR TITLE
Add a little Bun support

### DIFF
--- a/squeak_node.js
+++ b/squeak_node.js
@@ -67,7 +67,7 @@ Object.assign(global, {
 // Extend the new global scope with a few browser/DOM classes and methods
 Object.assign(self, {
     localStorage: {},
-    WebSocket: require("./lib_node/WebSocket"),
+    WebSocket: typeof WebSocket === "undefined" ? require("./lib_node/WebSocket") : WebSocket,
     sha1: require("./lib/sha1"),
     btoa: function(string) {
         return Buffer.from(string, 'ascii').toString('base64');


### PR DESCRIPTION
Bun (self described as a Node.js drop-in replacement) already has a default WebSocket implementation. Use this if Bun is used.