### PR TITLE
Write file using TypedArray instead of DataView (Bun support)

### DIFF
--- a/vm.plugins.file.node.js
+++ b/vm.plugins.file.node.js
@@ -336,7 +336,9 @@ Object.extend(Squeak, {
     },
     filePut: function(fileName, buffer) {
         try {
-            fs.writeFileSync(fileName, new DataView(buffer));
+            // Node does not support ArrayBuffer and Bun does not support DataView,
+            // use a TypedArray as argument to writeFileSync.
+            fs.writeFileSync(fileName, new Uint8Array(buffer));
         } catch(e) {
             console.error("Failed to create file with content: " + fileName);
         }


### PR DESCRIPTION
Some more Bun support. Bun does not handle DataView and Node.js does not handle ArrayBuffer.
Common ground is to use a TypedArray (Uint8Array).
