### PR TITLE
Support running newer Cuis images (7.7, 7.9)

### DIFF
--- a/demo/vectorengine/index.html
+++ b/demo/vectorengine/index.html
@@ -1,0 +1,231 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Cuis VectorEngine — JS port demo &amp; benchmark</title>
+<style>
+  body { font: 14px/1.5 -apple-system, Helvetica, Arial, sans-serif; margin: 20px; color: #222; }
+  h1 { font-size: 18px; }
+  #wrap { display: flex; gap: 20px; flex-wrap: wrap; align-items: flex-start; }
+  canvas { border: 1px solid #ccc; image-rendering: pixelated; background: #fff; }
+  #stats { font-family: ui-monospace, Menlo, monospace; white-space: pre; background: #111; color: #0f0; padding: 12px; border-radius: 6px; min-width: 360px; }
+  button { font-size: 14px; padding: 6px 12px; }
+  .muted { color: #666; }
+</style>
+</head>
+<body>
+<h1>Cuis <code>VectorEngine</code> — faithful JS port (fill + stroke)</h1>
+<p class="muted">Anti-aliased vector shapes rasterized by a method-for-method JavaScript port of
+Cuis' <code>VectorEnginePlugin</code> (Juan Vuletich), running natively in the browser — no Squeak VM.
+Geometry → transform → line/quadratic/cubic flattening → 3-channel sub-pixel coverage →
+<code>blendFillOnly</code> / <code>blendStrokeAndFill</code> / <code>blendStrokeOnly</code>.
+Bands: filled · fill+stroke · stars · stroke-only spirals.</p>
+<div id="wrap">
+  <canvas id="cv" width="640" height="480"></canvas>
+  <div>
+    <div id="stats">running…</div>
+    <p><button id="bench">Run benchmark</button> <button id="redraw">Redraw</button></p>
+    <p class="muted" id="note"></p>
+  </div>
+</div>
+
+<script src="ve-core.js"></script>
+<script>
+const W = 640, H = 480, PIX = W*H;
+const cv = document.getElementById('cv'), ctx = cv.getContext('2d');
+const imgData = ctx.createImageData(W, H);
+
+// shared engine + buffers (allocated once)
+const ve = new VectorEngineCore();
+const targetBits = new Uint32Array(PIX);
+const edgeCounts = new Uint32Array(PIX);
+const alphaMask  = new Uint32Array(PIX);
+const morphIds   = new Uint32Array(PIX);
+const contour    = new Float32Array(H*2);
+ve.setTarget(targetBits, morphIds, edgeCounts, alphaMask, contour, W, H);
+ve.antiAliasingWidthSubPixelDeltaHopLength(1.0, 0.0, 0.75); // subPixelDelta 0 → clean grayscale AA
+ve.setStrokeWidth(0.0);                                     // fill-only
+ve.geometryTx(1,0,0, 0,1,0);
+ve.currentMorph(1, false);
+
+const KAPPA = 0.5522847498307936;
+
+// emit a closed circle path (4 cubic beziers) — caller sets colors/stroke + blends
+function circlePath(cx, cy, r) {
+  ve.initializePath();
+  ve.newTrajectoryFragment();
+  const k = r*KAPPA;
+  ve.pvt_cubicBezierFromXY(cx+r, cy,   cx,   cy+r, cx+r, cy+k, cx+k, cy+r);
+  ve.pvt_cubicBezierFromXY(cx,   cy+r, cx-r, cy,   cx-k, cy+r, cx-r, cy+k);
+  ve.pvt_cubicBezierFromXY(cx-r, cy,   cx,   cy-r, cx-r, cy-k, cx-k, cy-r);
+  ve.pvt_cubicBezierFromXY(cx,   cy-r, cx+r, cy,   cx+k, cy-r, cx+r, cy-k);
+  ve.updateContourLastLine();
+}
+
+// fill a circle
+function fillCircle(cx, cy, r, R, G, B, A) {
+  ve.setStrokeWidth(0.0);
+  ve.fillRGBA(R, G, B, A);
+  circlePath(cx, cy, r);
+  clampedBlend(false);
+}
+
+// fill + stroke a circle (interior fill, anti-aliased outline)
+function fillStrokeCircle(cx, cy, r, fR,fG,fB,fA, sR,sG,sB,sA, sw) {
+  ve.setStrokeWidth(sw);
+  ve.fillRGBA(fR,fG,fB,fA);
+  ve.strokeRGBA(sR,sG,sB,sA);
+  circlePath(cx, cy, r);
+  clampedBlend(true); // stroke+fill
+}
+
+// stroke-only open path: a poly-line spiral (no interior fill)
+function strokeSpiral(cx, cy, turns, maxR, sR,sG,sB,sA, sw) {
+  ve.setStrokeWidth(sw);
+  ve.fillRGBA(0,0,0,0);            // fillA = 0 → no winding/edge counts, stroke only
+  ve.strokeRGBA(sR,sG,sB,sA);
+  ve.initializePath();
+  ve.newTrajectoryFragment();
+  const steps = turns*40;
+  let px = cx, py = cy;
+  for (let i=1;i<=steps;i++){
+    const a = i/steps*turns*2*Math.PI;
+    const rr = maxR*i/steps;
+    const x = cx + Math.cos(a)*rr, y = cy + Math.sin(a)*rr;
+    ve.pvt_lineFromXY(px, py, x, y);
+    px = x; py = y;
+  }
+  ve.updateContourLastLine();
+  clampedBlend(2); // stroke only
+}
+
+// fill a polygon (closed) from [x0,y0,x1,y1,...]
+function fillPolygon(pts, R, G, B, A) {
+  ve.setStrokeWidth(0.0);
+  ve.fillRGBA(R, G, B, A);
+  ve.initializePath();
+  ve.newTrajectoryFragment();
+  const n = pts.length/2;
+  for (let i=0;i<n;i++){
+    const ax=pts[i*2], ay=pts[i*2+1], j=(i+1)%n, bx=pts[j*2], by=pts[j*2+1];
+    ve.pvt_lineFromXY(ax, ay, bx, by);
+  }
+  ve.updateContourLastLine();
+  clampedBlend();
+}
+
+// mode: false=fill only, true=stroke+fill, 2=stroke only
+function clampedBlend(mode) {
+  let l = ve.spanLeftPx(),  t = ve.spanTopPx();
+  let r = ve.spanRightPx(), b = ve.spanBottomPx();
+  if (l < 0) l = 0; if (t < 0) t = 0;
+  if (r > W-1) r = W-1; if (b > H-1) b = H-1;
+  if (r < l || b < t) return;
+  if (mode === 2)      ve.blendStrokeOnly(l, t, r, b);
+  else if (mode)       ve.blendStrokeAndFill(l, t, r, b);
+  else                 ve.blendFillOnly(l, t, r, b);
+}
+
+// build a representative, curve-heavy scene
+function drawScene() {
+  targetBits.fill(0xFF202840);   // opaque dark-blue background (0xAARRGGBB)
+  let shapes = 0;
+  // Band 1: translucent filled circles
+  for (let gx=0; gx<8; gx++) {
+    const cx = 44 + gx*78, cy = 46, r = 26 + ((gx*7)%14);
+    const [R,G,B] = hsl((gx*40)%360, 0.7, 0.6);
+    fillCircle(cx, cy, r, R, G, B, 0.75); shapes++;
+  }
+  // Band 2: fill + anti-aliased stroke outline
+  for (let gx=0; gx<8; gx++) {
+    const cx = 44 + gx*78, cy = 138, r = 24 + ((gx*5)%16);
+    const [R,G,B]  = hsl((gx*47+20)%360, 0.65, 0.62);
+    const [sr,sg,sb] = hsl((gx*47+20)%360, 0.9, 0.25);
+    fillStrokeCircle(cx, cy, r, R,G,B,0.85, sr,sg,sb,1.0, 3.0); shapes++;
+  }
+  // Band 3: filled + stroked stars
+  for (let i=0;i<8;i++){
+    const cx = 50 + i*74, cy = 232, rr = 26 + (i*5)%16;
+    const pts = [], spokes = 5;
+    for (let s=0;s<spokes*2;s++){
+      const ang = s*Math.PI/spokes - Math.PI/2, rad = (s%2===0)? rr : rr*0.45;
+      pts.push(cx + Math.cos(ang)*rad, cy + Math.sin(ang)*rad);
+    }
+    ve.setStrokeWidth(2.5);
+    ve.fillRGBA(...hsl((i*36)%360,0.8,0.6), 0.9);
+    ve.strokeRGBA(1,1,1,0.95);
+    ve.initializePath(); ve.newTrajectoryFragment();
+    for (let k=0;k<spokes*2;k++){ const j=(k+1)%(spokes*2); ve.pvt_lineFromXY(pts[k*2],pts[k*2+1],pts[j*2],pts[j*2+1]); }
+    ve.updateContourLastLine();
+    clampedBlend(true); shapes++;
+  }
+  // Band 4: stroke-only spirals (open paths)
+  for (let i=0;i<6;i++){
+    const cx = 70 + i*100, cy = 360, [sr,sg,sb]=hsl((i*60)%360,0.85,0.6);
+    strokeSpiral(cx, cy, 3.5, 38, sr,sg,sb,0.95, 2.0); shapes++;
+  }
+  return shapes;
+}
+
+function hsl(h,s,l){ // -> [r,g,b] in 0..1
+  h/=360; const a=s*Math.min(l,1-l);
+  const f=n=>{const k=(n+h*12)%12; return l-a*Math.max(-1,Math.min(k-3,9-k,1));};
+  return [f(0),f(8),f(4)];
+}
+
+function blit() {
+  const d = imgData.data;
+  for (let i=0;i<PIX;i++){
+    const w = targetBits[i];
+    d[i*4]   = (w>>>16)&255;
+    d[i*4+1] = (w>>>8)&255;
+    d[i*4+2] = w&255;
+    d[i*4+3] = (w>>>24)&255;
+  }
+  ctx.putImageData(imgData, 0, 0);
+}
+
+const shapeCount = drawScene();
+blit();
+
+function runBenchmark() {
+  document.getElementById('stats').textContent = "benchmarking…";
+  setTimeout(() => {
+    // warm up
+    for (let i=0;i<10;i++) drawScene();
+    const FRAMES = 200;
+    const t0 = performance.now();
+    for (let i=0;i<FRAMES;i++) drawScene();
+    const t1 = performance.now();
+    blit();
+    const ms = (t1-t0)/FRAMES;
+    const fps = 1000/ms;
+    const mpix = (PIX/1e6) / (ms/1000);            // full-frame pixels touched / s (lower bound: only spans are blended)
+    const shapesPerSec = (shapeCount*FRAMES)/((t1-t0)/1000);
+    document.getElementById('stats').textContent =
+`VectorEngine JS port — benchmark
+--------------------------------
+canvas        : ${W} x ${H}  (${(PIX/1e3)|0}k px)
+shapes/frame  : ${shapeCount}  (fill, fill+stroke, stars, stroke-only spirals)
+frames timed  : ${FRAMES}
+--------------------------------
+ms / frame    : ${ms.toFixed(3)} ms
+frames / sec  : ${fps.toFixed(1)} fps
+shapes / sec  : ${(shapesPerSec/1000).toFixed(1)}k
+throughput    : ${mpix.toFixed(1)} Mpx/s (frame area)
+--------------------------------
+RESULT_MS=${ms.toFixed(3)} RESULT_FPS=${fps.toFixed(1)} RESULT_SHAPES_PER_S=${shapesPerSec.toFixed(0)}`;
+    window.__veResult = { ms, fps, shapesPerSec, shapeCount };
+  }, 50);
+}
+
+document.getElementById('bench').onclick = runBenchmark;
+document.getElementById('redraw').onclick = () => { drawScene(); blit(); };
+document.getElementById('note').textContent =
+  "The same algorithm runs in Cuis today as interpreted Smalltalk (VectorEngineSmalltalk) when no plugin is present.";
+
+// auto-run benchmark shortly after load (for headless capture)
+window.__autobench = setTimeout(runBenchmark, 300);
+</script>
+</body>
+</html>

--- a/demo/vectorengine/ve-core.js
+++ b/demo/vectorengine/ve-core.js
@@ -1,0 +1,465 @@
+"use strict";
+/*
+ * ve-core.js — a faithful JavaScript port of the *fill* path of Cuis Smalltalk's
+ * VectorEnginePlugin (sub-pixel anti-aliasing analytic rasterizer by Juan Vuletich).
+ *
+ * Ported method-for-method from:
+ *   Cuis-Smalltalk-Dev/Packages/Features/VectorEnginePlugin.pck.st
+ * following the C (`cCode:`) branches. Operates on plain typed arrays — no Squeak
+ * VM needed — so we can prove the algorithm runs natively in the browser and measure
+ * its speed independently of SqueakJS.
+ *
+ * Scope: the geometry + fill pipeline (transform, line/quadratic/cubic flattening,
+ * coverage accumulation, and blendFillOnly). Stroke and text are intentionally out of
+ * scope for this validation; they reuse the very same primitives.
+ *
+ * Array indexing note: the Smalltalk source uses 1-based `at:`. This port keeps the
+ * exact index arithmetic but treats the typed arrays as 0-based throughout — the
+ * algorithm is internally consistent (it reads and writes the same indices), so the
+ * rendered result is identical.
+ */
+
+function VectorEngineCore() {
+    // ---- state (mirrors the plugin instance variables) ----
+    this.targetBits = null;   // Uint32Array, 0xAARRGGBB per pixel
+    this.morphIds = null;     // Uint32Array
+    this.edgeCounts = null;   // Uint32Array (3x 8-bit winding counts packed R/G/B)
+    this.alphaMask = null;    // Uint32Array (3x 7-bit edge AA coverage packed)
+    this.contour = null;      // Float32Array, 2 per scanline (left,right)
+    this.targetWidth = 0;
+    this.targetHeight = 0;
+
+    this.antiAliasingWidth = 1.0;
+    this.subPixelDelta = 0.0;
+    this.hop = 0.75;
+    this.strokeWidth = 0.0;
+    this.strokeR = this.strokeG = this.strokeB = 0.0; this.strokeA = 0.0;
+    this.fillR = this.fillG = this.fillB = 0.0; this.fillA = 1.0;
+
+    this.txA11 = 1; this.txA12 = 0; this.txA13 = 0;
+    this.txA21 = 0; this.txA22 = 1; this.txA23 = 0;
+
+    this.currentMorphId = 0;
+    this.currentClipsSubmorphs = false;
+    this.clipCurrentMorph = false;
+    this.clipLeft = 0; this.clipTop = 0; this.clipRight = 0; this.clipBottom = 0;
+
+    this.auxAntiAliasingWidthScaledInverse = 127.0;
+    this.auxStrokeWidthDilatedHalf = 0.5;
+    this.auxStrokeWidthDilatedHalfSquared = 0.25;
+    this.auxStrokeWidthErodedHalfSquared = 0.25;
+
+    this.spanLeft = 0; this.spanTop = 0; this.spanRight = 0; this.spanBottom = 0;
+    this.prevYTruncated = 0x7FFFFFFF;
+    this.prevYRounded = 0x7FFFFFFF;
+    this.leftAtThisY = 0; this.rightAtThisY = 0;
+}
+
+VectorEngineCore.prototype = {
+
+    // ---------- accessors ----------
+    setTarget: function(targetBits, morphIds, edgeCounts, alphaMask, contour, w, h) {
+        this.targetBits = targetBits; this.morphIds = morphIds;
+        this.edgeCounts = edgeCounts; this.alphaMask = alphaMask; this.contour = contour;
+        this.targetWidth = w; this.targetHeight = h;
+        this.clipLeft = 0; this.clipTop = 0; this.clipRight = w - 1; this.clipBottom = h - 1;
+    },
+    antiAliasingWidthSubPixelDeltaHopLength: function(aa, spd, hopLen) {
+        this.antiAliasingWidth = aa;
+        this.auxAntiAliasingWidthScaledInverse = 127.0 / aa;
+        this.subPixelDelta = spd;
+        this.hop = hopLen;
+    },
+    fillRGBA: function(r, g, b, a) { this.fillR = r*255.0; this.fillG = g*255.0; this.fillB = b*255.0; this.fillA = a; },
+    strokeRGBA: function(r, g, b, a) { this.strokeR = r*255.0; this.strokeG = g*255.0; this.strokeB = b*255.0; this.strokeA = a; },
+    setStrokeWidth: function(w) {
+        this.strokeWidth = w;
+        this.auxStrokeWidthDilatedHalf = (w + this.antiAliasingWidth) * 0.5;
+        this.auxStrokeWidthDilatedHalfSquared = this.auxStrokeWidthDilatedHalf * this.auxStrokeWidthDilatedHalf;
+        var swErodedHalf = (w - this.antiAliasingWidth) * 0.5;
+        this.auxStrokeWidthErodedHalfSquared = swErodedHalf * Math.abs(swErodedHalf);
+    },
+    geometryTx: function(a11,a12,a13,a21,a22,a23) {
+        this.txA11=a11; this.txA12=a12; this.txA13=a13; this.txA21=a21; this.txA22=a22; this.txA23=a23;
+    },
+    setClip: function(l,t,r,b) { this.clipLeft=l; this.clipTop=t; this.clipRight=r; this.clipBottom=b; },
+    currentMorph: function(id, clipsSubmorphs) {
+        this.currentMorphId = id;
+        if (id === 0) this.clipCurrentMorph = false;
+        this.currentClipsSubmorphs = clipsSubmorphs;
+    },
+    initializePath: function() {
+        this.spanLeft = this.targetWidth; this.spanTop = this.targetHeight;
+        this.spanRight = 0; this.spanBottom = 0;
+        this.prevYRounded = 0x7FFFFFFF;
+    },
+    initializeTrajectoryFragment: function() { this.prevYTruncated = 0x7FFFFFFF; },
+    newTrajectoryFragment: function() { this.initializeTrajectoryFragment(); },
+    resetContour: function(t, b) {
+        this.leftAtThisY = this.targetWidth; this.rightAtThisY = 0;
+        for (var y = t; y <= b; y++) { this.contour[y*2] = this.targetWidth; this.contour[y*2+1] = 0; }
+    },
+    // span getters (integer pixel bounds, dilated by stroke half-width + AA)
+    spanLeftPx:   function() { return (this.spanLeft - this.auxStrokeWidthDilatedHalf - this.subPixelDelta + 1) | 0; },
+    spanRightPx:  function() { return ((this.spanRight + this.auxStrokeWidthDilatedHalf + this.subPixelDelta) | 0) + 1; },
+    spanTopPx:    function() { return (this.spanTop - this.auxStrokeWidthDilatedHalf + 1) | 0; },
+    spanBottomPx: function() { return (this.spanBottom + this.auxStrokeWidthDilatedHalf) | 0; },
+
+    // ---------- path flattening ----------
+    pvt_lineFromXY: function(xFrom, yFrom, xTo, yTo) {
+        var txFrom = xFrom*this.txA11 + yFrom*this.txA12 + this.txA13;
+        var tyFrom = xFrom*this.txA21 + yFrom*this.txA22 + this.txA23;
+        var txTo = xTo*this.txA11 + yTo*this.txA12 + this.txA13;
+        var tyTo = xTo*this.txA21 + yTo*this.txA22 + this.txA23;
+        var dx = Math.abs(txTo-txFrom), dy = Math.abs(tyTo-tyFrom);
+        var hops = ((Math.max(dx,dy)/this.hop)|0) + 1;
+        if (txFrom < txTo) { if (txFrom<this.spanLeft) this.spanLeft=txFrom; if (txTo>this.spanRight) this.spanRight=txTo; }
+        else { if (txTo<this.spanLeft) this.spanLeft=txTo; if (txFrom>this.spanRight) this.spanRight=txFrom; }
+        if (tyFrom < tyTo) { if (tyFrom<this.spanTop) this.spanTop=tyFrom; if (tyTo>this.spanBottom) this.spanBottom=tyTo; }
+        else { if (tyTo<this.spanTop) this.spanTop=tyTo; if (tyFrom>this.spanBottom) this.spanBottom=tyFrom; }
+        var t = 0.0, increment = 1.0/hops, x, y, oneLessT;
+        while (t < 1.0) {
+            oneLessT = 1.0 - t;
+            x = oneLessT*txFrom + t*txTo;
+            y = oneLessT*tyFrom + t*tyTo;
+            this.updateAlphas(x, y);
+            if (this.fillA !== 0.0) this.updateEdgeCount(x, y);
+            this.updateContour(x, y);
+            t += increment;
+        }
+        this.updateAlphas(txTo, tyTo);
+        if (this.fillA !== 0.0) this.updateEdgeCount(txTo, tyTo);
+        this.updateContour(txTo, tyTo);
+    },
+    pvt_quadraticBezierFromXY: function(xFrom,yFrom,xTo,yTo,xControl,yControl) {
+        if ((xControl===xTo && yControl===yTo) || (xControl===xFrom && yControl===yFrom))
+            return this.pvt_lineFromXY(xFrom,yFrom,xTo,yTo);
+        var txFrom = xFrom*this.txA11+yFrom*this.txA12+this.txA13, tyFrom = xFrom*this.txA21+yFrom*this.txA22+this.txA23;
+        var txTo = xTo*this.txA11+yTo*this.txA12+this.txA13, tyTo = xTo*this.txA21+yTo*this.txA22+this.txA23;
+        var txControl = xControl*this.txA11+yControl*this.txA12+this.txA13, tyControl = xControl*this.txA21+yControl*this.txA22+this.txA23;
+        var dx = Math.abs(txTo-txFrom), dx2 = Math.abs(txControl-txFrom);
+        var dy = Math.abs(tyTo-tyFrom), dy2 = Math.abs(tyControl-tyFrom);
+        if (dx < 1.0 && dx2 < 1.0) return this.pvt_lineFromXY(xFrom,yFrom,xTo,yTo);
+        if (dy < 1.0 && dy2 < 1.0) return this.pvt_lineFromXY(xFrom,yFrom,xTo,yTo);
+        var xMinEnd = Math.min(txFrom,txTo), xMaxEnd = Math.max(txFrom,txTo);
+        var yMinEnd = Math.min(tyFrom,tyTo), yMaxEnd = Math.max(tyFrom,tyTo);
+        this.spanLeft = Math.min(this.spanLeft, Math.min(xMinEnd, (xMinEnd+txControl)/2.0));
+        this.spanRight = Math.max(this.spanRight, Math.max(xMaxEnd, (xMaxEnd+txControl)/2.0));
+        this.spanTop = Math.min(this.spanTop, Math.min(yMinEnd, (yMinEnd+tyControl)/2.0));
+        this.spanBottom = Math.max(this.spanBottom, Math.max(yMaxEnd, (yMaxEnd+tyControl)/2.0));
+        var x = txFrom, y = tyFrom;
+        this.updateAlphas(x,y); if (this.fillA!==0.0) this.updateEdgeCount(x,y); this.updateContour(x,y);
+        var increment = Math.min(0.5/Math.max(dx,dy), 0.5), t = 0.0, t0,x0,y0,oneLessT,f1,f2,f3,len,correction;
+        do {
+            t0=t; x0=x; y0=y;
+            t = t0+increment; oneLessT = 1.0-t;
+            f1=oneLessT*oneLessT; f2=2.0*oneLessT*t; f3=t*t;
+            x = f1*txFrom + f2*txControl + f3*txTo; y = f1*tyFrom + f2*tyControl + f3*tyTo;
+            dx=x-x0; dy=y-y0; len=Math.sqrt(dx*dx+dy*dy); correction=this.hop/len;
+            do {
+                increment = increment/len*this.hop;
+                t = t0+increment; oneLessT=1.0-t;
+                f1=oneLessT*oneLessT; f2=2.0*oneLessT*t; f3=t*t;
+                x = f1*txFrom + f2*txControl + f3*txTo; y = f1*tyFrom + f2*tyControl + f3*tyTo;
+                dx=x-x0; dy=y-y0; len=Math.sqrt(dx*dx+dy*dy); correction=this.hop/len;
+            } while (correction < 1.0);
+            if (t < 1.0) {
+                this.updateAlphas(x,y); if (this.fillA!==0.0) this.updateEdgeCount(x,y); this.updateContour(x,y);
+            }
+        } while (t < 1.0);
+        this.updateAlphas(txTo,tyTo); if (this.fillA!==0.0) this.updateEdgeCount(txTo,tyTo); this.updateContour(txTo,tyTo);
+    },
+    pvt_cubicBezierFromXY: function(xFrom,yFrom,xTo,yTo,xC1,yC1,xC2,yC2) {
+        var txFrom=xFrom*this.txA11+yFrom*this.txA12+this.txA13, tyFrom=xFrom*this.txA21+yFrom*this.txA22+this.txA23;
+        var txTo=xTo*this.txA11+yTo*this.txA12+this.txA13, tyTo=xTo*this.txA21+yTo*this.txA22+this.txA23;
+        var txC1=xC1*this.txA11+yC1*this.txA12+this.txA13, tyC1=xC1*this.txA21+yC1*this.txA22+this.txA23;
+        var txC2=xC2*this.txA11+yC2*this.txA12+this.txA13, tyC2=xC2*this.txA21+yC2*this.txA22+this.txA23;
+        var dx=Math.abs(txC1-txFrom), dx2=Math.abs(txTo-txC2), dx3=Math.abs(txC2-txC1);
+        var dy=Math.abs(tyC1-tyFrom), dy2=Math.abs(tyTo-tyC2), dy3=Math.abs(tyC2-tyC1);
+        dx = Math.max(Math.max(dx,dx2)*3, dx3*1.5);
+        dy = Math.max(Math.max(dy,dy2)*3, dy3*1.5);
+        var hops = ((Math.max(dx,dy)/this.hop)|0) + 1;
+        var xMinEnd=Math.min(txFrom,txTo), xMaxEnd=Math.max(txFrom,txTo);
+        var yMinEnd=Math.min(tyFrom,tyTo), yMaxEnd=Math.max(tyFrom,tyTo);
+        this.spanLeft = Math.min(this.spanLeft, Math.min(xMinEnd, xMinEnd*0.25 + Math.min(txC1,txC2)*0.75));
+        this.spanRight = Math.max(this.spanRight, Math.max(xMaxEnd, xMaxEnd*0.25 + Math.max(txC1,txC2)*0.75));
+        this.spanTop = Math.min(this.spanTop, Math.min(yMinEnd, yMinEnd*0.25 + Math.min(tyC1,tyC2)*0.75));
+        this.spanBottom = Math.max(this.spanBottom, Math.max(yMaxEnd, yMaxEnd*0.25 + Math.max(tyC1,tyC2)*0.75));
+        var t=0.0, increment=1.0/hops, oneLessT,f1,f23,f2,f3,f4,x,y;
+        while (t < 1.0) {
+            oneLessT=1.0-t;
+            f1=oneLessT*oneLessT*oneLessT; f23=3.0*oneLessT*t; f2=f23*oneLessT; f3=f23*t; f4=t*t*t;
+            x = f1*txFrom + f2*txC1 + f3*txC2 + f4*txTo;
+            y = f1*tyFrom + f2*tyC1 + f3*tyC2 + f4*tyTo;
+            this.updateAlphas(x,y); if (this.fillA!==0.0) this.updateEdgeCount(x,y); this.updateContour(x,y);
+            t += increment;
+        }
+        this.updateAlphas(txTo,tyTo); if (this.fillA!==0.0) this.updateEdgeCount(txTo,tyTo); this.updateContour(txTo,tyTo);
+    },
+
+    // ---------- coverage accumulation ----------
+    updateAlphas: function(x, y) {
+        var t = (y - this.auxStrokeWidthDilatedHalf + 1)|0; if (t < this.clipTop) t = this.clipTop;
+        var b = (y + this.auxStrokeWidthDilatedHalf)|0; if (b > this.clipBottom) b = this.clipBottom;
+        var l = (x - this.auxStrokeWidthDilatedHalf - this.subPixelDelta + 1)|0; if (l < this.clipLeft) l = this.clipLeft;
+        var r = (x + this.auxStrokeWidthDilatedHalf + this.subPixelDelta)|0; if (r > this.clipRight) r = this.clipRight;
+        var W=this.targetWidth, am=this.alphaMask, spd=this.subPixelDelta;
+        var dilHalf=this.auxStrokeWidthDilatedHalf, dilHalfSq=this.auxStrokeWidthDilatedHalfSquared;
+        var erHalfSq=this.auxStrokeWidthErodedHalfSquared, aaInv=this.auxAntiAliasingWidthScaledInverse;
+        for (var displayY = t; displayY <= b; displayY++) {
+            var pixelIndex = displayY*W + l - 1;
+            var dy = displayY - y, dySquared = dy*dy;
+            for (var displayX = l; displayX <= r; displayX++) {
+                pixelIndex++;
+                var alphaWord = am[pixelIndex];
+                if (alphaWord === 0x007F7F7F) continue;
+                var redAlpha = alphaWord & 0x7F0000, greenAlpha = alphaWord & 0x7F00, blueAlpha = alphaWord & 0x7F;
+                var doUpdate = false, dx = displayX - x, dxp, dist, cand;
+                // Red
+                dxp = dx - spd; dist = dxp*dxp + dySquared;
+                if (dist < dilHalfSq) {
+                    if (dist <= erHalfSq) cand = 0x7F0000;
+                    else cand = (((dilHalf - Math.sqrt(dist))*aaInv)>>>0) << 16;
+                    if (cand > redAlpha) { doUpdate = true; redAlpha = cand; }
+                }
+                // Green
+                dist = dx*dx + dySquared;
+                if (dist < dilHalfSq) {
+                    if (dist <= erHalfSq) cand = 0x7F00;
+                    else cand = (((dilHalf - Math.sqrt(dist))*aaInv)>>>0) << 8;
+                    if (cand > greenAlpha) { doUpdate = true; greenAlpha = cand; }
+                }
+                // Blue
+                dxp = dx + spd; dist = dxp*dxp + dySquared;
+                if (dist < dilHalfSq) {
+                    if (dist <= erHalfSq) cand = 0x7F;
+                    else cand = ((dilHalf - Math.sqrt(dist))*aaInv)>>>0;
+                    if (cand > blueAlpha) { doUpdate = true; blueAlpha = cand; }
+                }
+                if (doUpdate) am[pixelIndex] = (redAlpha | greenAlpha) | blueAlpha;
+            }
+        }
+    },
+    updateContour: function(x, y) {
+        var thisYRounded = (y + 0.5)|0;
+        if (thisYRounded >= 0 && thisYRounded <= this.targetHeight-1) {
+            if (thisYRounded !== this.prevYRounded) {
+                if (this.prevYRounded !== 0x7FFFFFFF) {
+                    this.contour[this.prevYRounded*2] = this.leftAtThisY;
+                    this.contour[this.prevYRounded*2+1] = this.rightAtThisY;
+                }
+                this.leftAtThisY = this.contour[thisYRounded*2];
+                this.rightAtThisY = this.contour[thisYRounded*2+1];
+                this.prevYRounded = thisYRounded;
+            }
+            if (x < this.leftAtThisY) this.leftAtThisY = x;
+            if (x > this.rightAtThisY) this.rightAtThisY = x;
+        }
+    },
+    updateContourLastLine: function() {
+        if (this.prevYRounded !== 0x7FFFFFFF) {
+            this.contour[this.prevYRounded*2] = this.leftAtThisY;
+            this.contour[this.prevYRounded*2+1] = this.rightAtThisY;
+        }
+    },
+    updateEdgeCount: function(x, y) {
+        var thisYTruncated = y|0;
+        if (thisYTruncated === this.prevYTruncated) return;
+        if (!(thisYTruncated >= this.clipTop-1 && thisYTruncated <= this.clipBottom)) return;
+        if (this.prevYTruncated === 0x7FFFFFFF) { this.prevYTruncated = thisYTruncated; return; }
+        var pixelY, redInc, greenInc, blueInc;
+        if (thisYTruncated > this.prevYTruncated) { pixelY = thisYTruncated; redInc=0x010000; greenInc=0x0100; blueInc=0x01; }
+        else { pixelY = this.prevYTruncated; redInc=0xFF0000; greenInc=0xFF00; blueInc=0xFF; }
+        this.prevYTruncated = thisYTruncated;
+        var ec = this.edgeCounts, W = this.targetWidth, spd = this.subPixelDelta, cl = this.clipLeft, cr = this.clipRight;
+        var base = pixelY*W;
+        var redOffset = Math.max((x+spd+1)|0, cl);
+        var greenOffset = Math.max((x+1)|0, cl);
+        var blueOffset = Math.max((x-spd+1)|0, cl);
+        var rIdx = base+redOffset, gIdx = base+greenOffset, bIdx = base+blueOffset;
+        var cw, rc, gc, bc, rest;
+        if (rIdx === bIdx) {
+            if (redOffset <= cr) {
+                cw = ec[rIdx];
+                rc = (cw+redInc)&0xFF0000; gc = (cw+greenInc)&0xFF00; bc = (cw+blueInc)&0xFF;
+                ec[rIdx] = (rc|gc)|bc;
+            }
+        } else if (rIdx === gIdx) {
+            if (redOffset <= cr) { cw=ec[rIdx]; rc=(cw+redInc)&0xFF0000; gc=(cw+greenInc)&0xFF00; rest=cw&0xFF; ec[rIdx]=(rc|gc)|rest; }
+            if (blueOffset <= cr) { cw=ec[bIdx]; rest=cw&0xFFFF00; bc=(cw+blueInc)&0xFF; ec[bIdx]=rest|bc; }
+        } else {
+            if (redOffset <= cr) { cw=ec[rIdx]; rc=(cw+redInc)&0xFF0000; rest=cw&0xFFFF; ec[rIdx]=rc|rest; }
+            if (blueOffset <= cr) { cw=ec[bIdx]; rest=cw&0xFF0000; gc=(cw+greenInc)&0xFF00; bc=(cw+blueInc)&0xFF; ec[bIdx]=(rest|gc)|bc; }
+        }
+    },
+
+    // ---------- blend fill over background ----------
+    blendFillOnly: function(l, t, r, b) {
+        var W=this.targetWidth, ec=this.edgeCounts, am=this.alphaMask;
+        for (var displayY = t; displayY <= b; displayY++) {
+            var eR=0, eG=0, eB=0;
+            var pixelIndex = displayY*W + l - 1;
+            for (var displayX = l; displayX <= r; displayX++) {
+                pixelIndex++;
+                var ew = ec[pixelIndex];
+                if (ew !== 0) ec[pixelIndex] = 0;
+                // 8-bit wraparound counts, signed
+                var er = (ew & 0xFF0000) >>> 16; if (er > 127) er -= 256;
+                var eg = (ew & 0xFF00) >>> 8;    if (eg > 127) eg -= 256;
+                var eb = (ew & 0xFF);            if (eb > 127) eb -= 256;
+                eR = (eR + er) & 0xFF; eG = (eG + eg) & 0xFF; eB = (eB + eb) & 0xFF;
+                var isR = (eR << 24) !== 0, isG = (eG << 24) !== 0, isB = (eB << 24) !== 0; // nonzero as int8
+                var aaw = am[pixelIndex];
+                if (aaw !== 0) am[pixelIndex] = 0;
+                if (aaw !== 0 || isR || isG || isB)
+                    this.blendFillOnlyAt(pixelIndex, isR, isG, isB, aaw);
+            }
+        }
+    },
+    blendFillOnlyAt: function(pixelIndex, isRedInside, isGreenInside, isBlueInside, antiAliasAlphasWord) {
+        var aRBits = antiAliasAlphasWord & 0x7F0000, aGBits = antiAliasAlphasWord & 0x7F00, aBBits = antiAliasAlphasWord & 0x7F;
+        if (isRedInside) aRBits = 0x7F0000 - aRBits;
+        if (isGreenInside) aGBits = 0x7F00 - aGBits;
+        if (isBlueInside) aBBits = 0x7F - aBBits;
+        var alphaR = (aRBits * (1.0/(127.0*256*256))) * this.fillA;
+        var alphaG = (aGBits * (1.0/(127.0*256))) * this.fillA;
+        var alphaB = (aBBits * (1.0/127.0)) * this.fillA;
+        var clippingAntiAliasBits = 0, morphIdWord;
+        if (this.currentClipsSubmorphs) {
+            morphIdWord = this.morphIds[pixelIndex];
+            clippingAntiAliasBits = morphIdWord & 0x7F;
+            var shifted = aGBits >>> 8;
+            if (shifted > clippingAntiAliasBits) clippingAntiAliasBits = shifted;
+        } else if (this.clipCurrentMorph) {
+            morphIdWord = this.morphIds[pixelIndex];
+            clippingAntiAliasBits = morphIdWord & 0x7F;
+            var caa = clippingAntiAliasBits * (1.0/127.0);
+            alphaR *= caa; alphaG *= caa; alphaB *= caa;
+        }
+        if (alphaR + alphaG + alphaB === 0.0) return;
+        var targetWord = this.targetBits[pixelIndex];
+        var resultAlphaBits = targetWord & 0xFF000000;
+        var resultRBits = targetWord & 0xFF0000, resultGBits = targetWord & 0xFF00, resultBBits = targetWord & 0xFF;
+        var targetAlpha = (resultAlphaBits>>>0) * (1.0/(255.0*256*256*256));
+        var unAlpha, resultAlpha, resultC;
+        if (alphaR !== 0.0) {
+            unAlpha = 1.0-alphaR; resultAlpha = alphaR + unAlpha*targetAlpha;
+            resultC = alphaR*this.fillR + (unAlpha*(resultRBits>>>16))*targetAlpha;
+            resultRBits = ((resultC/resultAlpha + 0.5)>>>0) << 16;
+        }
+        if (alphaG !== 0.0) {
+            unAlpha = 1.0-alphaG; resultAlpha = alphaG + unAlpha*targetAlpha;
+            resultC = alphaG*this.fillG + (unAlpha*(resultGBits>>>8))*targetAlpha;
+            resultGBits = ((resultC/resultAlpha + 0.5)>>>0) << 8;
+            resultAlphaBits = ((resultAlpha*255.0 + 0.5)>>>0) << 24;
+        }
+        if (alphaB !== 0.0) {
+            unAlpha = 1.0-alphaB; resultAlpha = alphaB + unAlpha*targetAlpha;
+            resultC = alphaB*this.fillB + (unAlpha*resultBBits)*targetAlpha;
+            resultBBits = (resultC/resultAlpha + 0.5)>>>0;
+        }
+        this.targetBits[pixelIndex] = (((resultAlphaBits | resultRBits) | resultGBits) | resultBBits) >>> 0;
+        this.morphIds[pixelIndex] = ((this.currentMorphId << 8) + clippingAntiAliasBits) >>> 0;
+    },
+
+    // ---------- blend stroke (+ fill) over background ----------
+    blendStrokeAndFill: function(l, t, r, b) {
+        var W=this.targetWidth, ec=this.edgeCounts, am=this.alphaMask;
+        for (var displayY = t; displayY <= b; displayY++) {
+            var eR=0, eG=0, eB=0;
+            var pixelIndex = displayY*W + l - 1;
+            for (var displayX = l; displayX <= r; displayX++) {
+                pixelIndex++;
+                var ew = ec[pixelIndex];
+                if (ew !== 0) ec[pixelIndex] = 0;
+                var er = (ew & 0xFF0000) >>> 16; if (er > 127) er -= 256;
+                var eg = (ew & 0xFF00) >>> 8;    if (eg > 127) eg -= 256;
+                var eb = (ew & 0xFF);            if (eb > 127) eb -= 256;
+                eR = (eR + er) & 0xFF; eG = (eG + eg) & 0xFF; eB = (eB + eb) & 0xFF;
+                var aaw = am[pixelIndex];
+                if (aaw !== 0) am[pixelIndex] = 0;
+                if (aaw !== 0 || eR !== 0 || eG !== 0 || eB !== 0)
+                    this.blendStrokeAndFillAt(pixelIndex, eR!==0, eG!==0, eB!==0, aaw);
+            }
+        }
+    },
+    blendStrokeAndFillAt: function(pixelIndex, isRedInside, isGreenInside, isBlueInside, antiAliasAlphasWord) {
+        var aRBits = antiAliasAlphasWord & 0x7F0000, aGBits = antiAliasAlphasWord & 0x7F00, aBBits = antiAliasAlphasWord & 0x7F;
+        var aRA = aRBits * (1.0/(127.0*256*256)), aGA = aGBits * (1.0/(127.0*256)), aBA = aBBits * (1.0/127.0);
+        var alphaR, alphaG, alphaB, foreR, foreG, foreB;
+        if (isRedInside)   { alphaR = aRA*this.strokeA + (1.0-aRA)*this.fillA; foreR = aRA*this.strokeR + (1.0-aRA)*this.fillR; }
+        else               { alphaR = aRA*this.strokeA; foreR = this.strokeR; }
+        if (isGreenInside) { alphaG = aGA*this.strokeA + (1.0-aGA)*this.fillA; foreG = aGA*this.strokeG + (1.0-aGA)*this.fillG; }
+        else               { alphaG = aGA*this.strokeA; foreG = this.strokeG; }
+        if (isBlueInside)  { alphaB = aBA*this.strokeA + (1.0-aBA)*this.fillA; foreB = aBA*this.strokeB + (1.0-aBA)*this.fillB; }
+        else               { alphaB = aBA*this.strokeA; foreB = this.strokeB; }
+        var clippingAntiAliasBits = 0, morphIdWord;
+        if (this.currentClipsSubmorphs) {
+            if (isGreenInside) clippingAntiAliasBits = 0x7F;
+            else {
+                morphIdWord = this.morphIds[pixelIndex]; clippingAntiAliasBits = morphIdWord & 0x7F;
+                var shifted = aGBits >>> 8; if (shifted > clippingAntiAliasBits) clippingAntiAliasBits = shifted;
+            }
+        } else if (this.clipCurrentMorph) {
+            morphIdWord = this.morphIds[pixelIndex]; clippingAntiAliasBits = morphIdWord & 0x7F;
+            var caa = clippingAntiAliasBits * (1.0/127.0); alphaR*=caa; alphaG*=caa; alphaB*=caa;
+        }
+        if (alphaR + alphaG + alphaB === 0.0) return;
+        this.composite(pixelIndex, alphaR, alphaG, alphaB, foreR, foreG, foreB, clippingAntiAliasBits);
+    },
+    blendStrokeOnly: function(l, t, r, b) {
+        var W=this.targetWidth, am=this.alphaMask;
+        for (var displayY = t; displayY <= b; displayY++) {
+            var pixelIndex = displayY*W + l - 1;
+            for (var displayX = l; displayX <= r; displayX++) {
+                pixelIndex++;
+                var aaw = am[pixelIndex];
+                if (aaw !== 0) { am[pixelIndex] = 0; this.blendStrokeOnlyAt(pixelIndex, aaw); }
+            }
+        }
+    },
+    blendStrokeOnlyAt: function(pixelIndex, antiAliasAlphasWord) {
+        var aRA = (antiAliasAlphasWord & 0x7F0000) * (1.0/(127.0*256*256));
+        var aGA = (antiAliasAlphasWord & 0x7F00) * (1.0/(127.0*256));
+        var aBA = (antiAliasAlphasWord & 0x7F) * (1.0/127.0);
+        var alphaR = aRA*this.strokeA, alphaG = aGA*this.strokeA, alphaB = aBA*this.strokeA;
+        var clippingAntiAliasBits = 0, morphIdWord;
+        if (this.currentClipsSubmorphs) {
+            morphIdWord = this.morphIds[pixelIndex]; clippingAntiAliasBits = morphIdWord & 0x7F;
+            var shifted = (antiAliasAlphasWord & 0x7F00) >>> 8; if (shifted > clippingAntiAliasBits) clippingAntiAliasBits = shifted;
+        } else if (this.clipCurrentMorph) {
+            morphIdWord = this.morphIds[pixelIndex]; clippingAntiAliasBits = morphIdWord & 0x7F;
+            var caa = clippingAntiAliasBits * (1.0/127.0); alphaR*=caa; alphaG*=caa; alphaB*=caa;
+        }
+        if (alphaR + alphaG + alphaB === 0.0) return;
+        this.composite(pixelIndex, alphaR, alphaG, alphaB, this.strokeR, this.strokeG, this.strokeB, clippingAntiAliasBits);
+    },
+    // shared per-channel "over" compositing with correct target translucency
+    composite: function(pixelIndex, alphaR, alphaG, alphaB, foreR, foreG, foreB, clippingAntiAliasBits) {
+        var targetWord = this.targetBits[pixelIndex];
+        var resultAlphaBits = targetWord & 0xFF000000;
+        var resultRBits = targetWord & 0xFF0000, resultGBits = targetWord & 0xFF00, resultBBits = targetWord & 0xFF;
+        var targetAlpha = (resultAlphaBits>>>0) * (1.0/(255.0*256*256*256));
+        var unAlpha, resultAlpha, resultC;
+        if (alphaR !== 0.0) {
+            unAlpha = 1.0-alphaR; resultAlpha = alphaR + unAlpha*targetAlpha;
+            resultC = alphaR*foreR + (unAlpha*(resultRBits>>>16))*targetAlpha;
+            resultRBits = ((resultC/resultAlpha + 0.5)>>>0) << 16;
+        }
+        if (alphaG !== 0.0) {
+            unAlpha = 1.0-alphaG; resultAlpha = alphaG + unAlpha*targetAlpha;
+            resultC = alphaG*foreG + (unAlpha*(resultGBits>>>8))*targetAlpha;
+            resultGBits = ((resultC/resultAlpha + 0.5)>>>0) << 8;
+            resultAlphaBits = ((resultAlpha*255.0 + 0.5)>>>0) << 24;
+        }
+        if (alphaB !== 0.0) {
+            unAlpha = 1.0-alphaB; resultAlpha = alphaB + unAlpha*targetAlpha;
+            resultC = alphaB*foreB + (unAlpha*resultBBits)*targetAlpha;
+            resultBBits = (resultC/resultAlpha + 0.5)>>>0;
+        }
+        this.targetBits[pixelIndex] = (((resultAlphaBits | resultRBits) | resultGBits) | resultBBits) >>> 0;
+        this.morphIds[pixelIndex] = ((this.currentMorphId << 8) + clippingAntiAliasBits) >>> 0;
+    },
+};
+
+if (typeof module === "object" && module.exports) module.exports = VectorEngineCore;

--- a/jit.js
+++ b/jit.js
@@ -543,7 +543,7 @@ to single-step.
                     break;
                 case 0x5E: this.generateBlockReturn();
                     break;
-                case 0x5F: break; // nop
+                case 0x5F: this.generateLabel(); break; // nop (still needs a label so following jump targets line up)
                 case 0x60: case 0x61: case 0x62: case 0x63: case 0x64: case 0x65: case 0x66: case 0x67:
                 case 0x68: case 0x69: case 0x6A: case 0x6B: case 0x6C: case 0x6D: case 0x6E: case 0x6F:
                     this.generateNumericOp(b);

--- a/plugins/VectorEnginePlugin.js
+++ b/plugins/VectorEnginePlugin.js
@@ -1,0 +1,596 @@
+"use strict";
+/*
+ * VectorEnginePlugin.js — a SqueakJS port of Cuis Smalltalk's VectorEnginePlugin
+ * (sub-pixel anti-aliasing analytic vector rasterizer by Juan Vuletich).
+ *
+ * Ported method-for-method from the generated C of the **plugin API v7**:
+ *   OpenSmalltalk-vm/src/plugins/VectorEnginePlugin/VectorEnginePlugin.c
+ *   (VectorEnginePlugin-jmv.26, pluginApiVersion = 7)
+ *
+ * Implements both the SubPixel and WholePixel (…WP) primitive sets. Cuis 7.9 drives the
+ * main Display through the WholePixel engine, so the WP path carries the C optimizations:
+ *   - `affectedBits` 16-pixel "dirty segment" skip in the blend loops,
+ *   - the opaque-fill fast-path (direct color write when targetAssumedOpaque & fillA=1),
+ *   - the dedicated zero-stroke 2x2 text path (updateAlphasWPZeroStroke).
+ * Per-scanline clipping (primSetClippingSpec) and clip-edge anti-aliasing are honored.
+ *
+ * Remaining simplification: the SubPixel blend loops still scan the full [l..r] span
+ * (pixel-identical output, just not affectedBits-accelerated); SubPixel is only used for
+ * small off-screen glyph caches, so it isn't on the hot path.
+ *
+ * Squeak arrays are 0-based typed arrays here; the C uses 0-based pointer indexing, so the
+ * index arithmetic is copied verbatim.
+ */
+
+function VectorEnginePlugin() {
+
+  var ip = null;               // interpreterProxy
+
+  // ---- engine state (mirrors the C module globals) ----
+  var targetBits=null, morphIds=null, edgeCounts=null, alphaMask=null, contour=null;
+  var edgeCountsWP=null, alphaMaskWP=null;   // whole-pixel engine: 8-bit ByteArray coverage
+  var affectedBits=null;       // 1 byte per 16 pixels: "this 16-px segment was touched" (blend-skip)
+  var wpMode=false;            // true when Cuis' WholePixel engine is active (vs SubPixel)
+  var clippingSpec=null;       // Int32Array of 2*height [left,right] per scanline, or null
+  var targetWidth=0, targetHeight=0, targetAssumedOpaque=0;
+  var antiAliasingWidth=1, auxAAInv=127, subPixelDelta=0, hop=0.75, strokeWidth=0;
+  var auxDilHalf=0.5, auxDilHalfSq=0.25, auxErHalfSq=0.25;
+  var strokeR=0,strokeG=0,strokeB=0,strokeA=0, fillR=0,fillG=0,fillB=0,fillA=1;
+  var txA11=1,txA12=0,txA13=0, txA21=0,txA22=1,txA23=0;
+  var currentMorphId=0;
+  var clipLeft=0, clipTop=0, clipRight=0, clipBottom=0;
+  var spanLeft=0, spanTop=0, spanRight=0, spanBottom=0;
+  var prevYTruncated=0x7FFFFFFF, prevYRounded=0x7FFFFFFF, leftAtThisY=0, rightAtThisY=0;
+  // dashed strokes
+  var dashedStrokeBits=0, dashBitCount=0, dashBitLength=0.0, dashBitOffset=0, trajectoryLength=0.0;
+
+  // ===== path flattening =====
+  function pvt_line(xFrom,yFrom,xTo,yTo) {
+    var tfx=xFrom*txA11+yFrom*txA12+txA13, tfy=xFrom*txA21+yFrom*txA22+txA23;
+    var ttx=xTo*txA11+yTo*txA12+txA13,     tty=xTo*txA21+yTo*txA22+txA23;
+    var dx=Math.abs(ttx-tfx), dy=Math.abs(tty-tfy);
+    var hops=((Math.max(dx,dy)/hop)|0)+1;
+    if (tfx<ttx){ if(tfx<spanLeft)spanLeft=tfx; if(ttx>spanRight)spanRight=ttx; } else { if(ttx<spanLeft)spanLeft=ttx; if(tfx>spanRight)spanRight=tfx; }
+    if (tfy<tty){ if(tfy<spanTop)spanTop=tfy; if(tty>spanBottom)spanBottom=tty; } else { if(tty<spanTop)spanTop=tty; if(tfy>spanBottom)spanBottom=tfy; }
+    var t=0.0, inc=1.0/hops, x,y,o;
+    while (t<1.0){ o=1.0-t; x=o*tfx+t*ttx; y=o*tfy+t*tty; updateAlphas(x,y); if(fillA!==0.0)updateEdgeCount(x,y); updateContour(x,y); t+=inc; }
+    updateAlphas(ttx,tty); if(fillA!==0.0)updateEdgeCount(ttx,tty); updateContour(ttx,tty);
+  }
+  function pvt_quad(xFrom,yFrom,xTo,yTo,xC,yC) {
+    if ((xC===xTo&&yC===yTo)||(xC===xFrom&&yC===yFrom)) return pvt_line(xFrom,yFrom,xTo,yTo);
+    var tfx=xFrom*txA11+yFrom*txA12+txA13, tfy=xFrom*txA21+yFrom*txA22+txA23;
+    var ttx=xTo*txA11+yTo*txA12+txA13,     tty=xTo*txA21+yTo*txA22+txA23;
+    var tcx=xC*txA11+yC*txA12+txA13,       tcy=xC*txA21+yC*txA22+txA23;
+    var dx=Math.abs(ttx-tfx), dx2=Math.abs(tcx-tfx), dy=Math.abs(tty-tfy), dy2=Math.abs(tcy-tfy);
+    if (dx<1.0&&dx2<1.0) return pvt_line(xFrom,yFrom,xTo,yTo);
+    if (dy<1.0&&dy2<1.0) return pvt_line(xFrom,yFrom,xTo,yTo);
+    var xMin=Math.min(tfx,ttx),xMax=Math.max(tfx,ttx),yMin=Math.min(tfy,tty),yMax=Math.max(tfy,tty);
+    spanLeft=Math.min(spanLeft,Math.min(xMin,(xMin+tcx)/2.0)); spanRight=Math.max(spanRight,Math.max(xMax,(xMax+tcx)/2.0));
+    spanTop=Math.min(spanTop,Math.min(yMin,(yMin+tcy)/2.0)); spanBottom=Math.max(spanBottom,Math.max(yMax,(yMax+tcy)/2.0));
+    var x=tfx,y=tfy; updateAlphas(x,y); if(fillA!==0.0)updateEdgeCount(x,y); updateContour(x,y);
+    var inc=Math.min(0.5/Math.max(dx,dy),0.5), t=0.0,t0,x0,y0,o,f1,f2,f3,len;
+    do {
+      t0=t;x0=x;y0=y; t=t0+inc;o=1.0-t; f1=o*o;f2=2.0*o*t;f3=t*t;
+      x=f1*tfx+f2*tcx+f3*ttx; y=f1*tfy+f2*tcy+f3*tty; dx=x-x0;dy=y-y0; len=Math.sqrt(dx*dx+dy*dy);
+      do { inc=inc/len*hop; t=t0+inc;o=1.0-t; f1=o*o;f2=2.0*o*t;f3=t*t;
+        x=f1*tfx+f2*tcx+f3*ttx; y=f1*tfy+f2*tcy+f3*tty; dx=x-x0;dy=y-y0; len=Math.sqrt(dx*dx+dy*dy);
+      } while (hop/len < 1.0);
+      if (t<1.0){ updateAlphas(x,y); if(fillA!==0.0)updateEdgeCount(x,y); updateContour(x,y); }
+    } while (t<1.0);
+    updateAlphas(ttx,tty); if(fillA!==0.0)updateEdgeCount(ttx,tty); updateContour(ttx,tty);
+  }
+  function pvt_cubic(xFrom,yFrom,xTo,yTo,xC1,yC1,xC2,yC2) {
+    var tfx=xFrom*txA11+yFrom*txA12+txA13, tfy=xFrom*txA21+yFrom*txA22+txA23;
+    var ttx=xTo*txA11+yTo*txA12+txA13,     tty=xTo*txA21+yTo*txA22+txA23;
+    var c1x=xC1*txA11+yC1*txA12+txA13, c1y=xC1*txA21+yC1*txA22+txA23;
+    var c2x=xC2*txA11+yC2*txA12+txA13, c2y=xC2*txA21+yC2*txA22+txA23;
+    var dx=Math.abs(c1x-tfx),dx2=Math.abs(ttx-c2x),dx3=Math.abs(c2x-c1x);
+    var dy=Math.abs(c1y-tfy),dy2=Math.abs(tty-c2y),dy3=Math.abs(c2y-c1y);
+    dx=Math.max(Math.max(dx,dx2)*3,dx3*1.5); dy=Math.max(Math.max(dy,dy2)*3,dy3*1.5);
+    var hops=((Math.max(dx,dy)/hop)|0)+1;
+    var xMin=Math.min(tfx,ttx),xMax=Math.max(tfx,ttx),yMin=Math.min(tfy,tty),yMax=Math.max(tfy,tty);
+    spanLeft=Math.min(spanLeft,Math.min(xMin,xMin*0.25+Math.min(c1x,c2x)*0.75));
+    spanRight=Math.max(spanRight,Math.max(xMax,xMax*0.25+Math.max(c1x,c2x)*0.75));
+    spanTop=Math.min(spanTop,Math.min(yMin,yMin*0.25+Math.min(c1y,c2y)*0.75));
+    spanBottom=Math.max(spanBottom,Math.max(yMax,yMax*0.25+Math.max(c1y,c2y)*0.75));
+    var t=0.0,inc=1.0/hops,o,f1,f23,f2,f3,f4,x,y;
+    while (t<1.0){ o=1.0-t; f1=o*o*o; f23=3.0*o*t; f2=f23*o; f3=f23*t; f4=t*t*t;
+      x=f1*tfx+f2*c1x+f3*c2x+f4*ttx; y=f1*tfy+f2*c1y+f3*c2y+f4*tty;
+      updateAlphas(x,y); if(fillA!==0.0)updateEdgeCount(x,y); updateContour(x,y); t+=inc; }
+    updateAlphas(ttx,tty); if(fillA!==0.0)updateEdgeCount(ttx,tty); updateContour(ttx,tty);
+  }
+
+  function arcImpl(cX,cY,rX,rY,start,sweep,rc,rs) {
+    var tcx=cX*txA11+cY*txA12+txA13, tcy=cX*txA21+cY*txA22+txA23;
+    var scale=Math.sqrt(txA11*txA11+txA21*txA21), trx=rX*scale, try_=rY*scale;
+    var hops=((Math.max(trx,try_)*Math.abs(sweep)/hop)|0)+2, d=hops;
+    for (var h=0; h<=hops; h++){
+      var ang=(h/d)*sweep+start, xp=Math.cos(ang)*trx, yp=Math.sin(ang)*try_;
+      var x=rc*xp-rs*yp+tcx, y=rs*xp+rc*yp+tcy;
+      if(x<spanLeft)spanLeft=x; if(y<spanTop)spanTop=y; if(x>spanRight)spanRight=x; if(y>spanBottom)spanBottom=y;
+      updateAlphas(x,y); if(fillA!==0.0)updateEdgeCount(x,y); updateContour(x,y);
+    }
+  }
+
+  // ===== coverage accumulation =====
+  function updateAlphas(x,y) {
+    if (wpMode) return updateAlphasWP(x,y);
+    if (dashBitLength !== 0.0) {
+      trajectoryLength += hop;
+      var bit = (((trajectoryLength/dashBitLength)|0) + dashBitOffset) % dashBitCount;
+      if (!(dashedStrokeBits & (1 << ((dashBitCount-bit)-1)))) return;
+    }
+    var t=((y-auxDilHalf)+1)|0; if(t<clipTop)t=clipTop;
+    var b=(y+auxDilHalf)|0; if(b>clipBottom)b=clipBottom;
+    var l=(((x-auxDilHalf)-subPixelDelta)+1)|0; if(l<clipLeft)l=clipLeft;
+    var r=((x+auxDilHalf)+subPixelDelta)|0; if(r>clipRight)r=clipRight;
+    for (var displayY=t; displayY<=b; displayY++) {
+      var pi=(displayY*targetWidth+l)-1, dy=displayY-y, dySq=dy*dy;
+      for (var displayX=l; displayX<=r; displayX++) {
+        pi++;
+        var aw=alphaMask[pi];
+        if (aw===0x7F7F7F) continue;
+        var dx=displayX-x, redA=aw&0x7F0000, grnA=aw&0x7F00, bluA=aw&0x7F, upd=false, dxp, dist, cand;
+        dxp=dx-subPixelDelta; dist=dxp*dxp+dySq;
+        if (dist<auxDilHalfSq){ cand=(((auxDilHalf-Math.sqrt(dist))*auxAAInv)|0)<<16; if(cand>redA){upd=true; redA=cand<0x7F0000?cand:0x7F0000;} }
+        dist=dx*dx+dySq;
+        if (dist<auxDilHalfSq){ cand=(((auxDilHalf-Math.sqrt(dist))*auxAAInv)|0)<<8; if(cand>grnA){upd=true; grnA=cand<0x7F00?cand:0x7F00;} }
+        dxp=dx+subPixelDelta; dist=dxp*dxp+dySq;
+        if (dist<auxDilHalfSq){ cand=((auxDilHalf-Math.sqrt(dist))*auxAAInv)|0; if(cand>bluA){upd=true; bluA=cand<0x7F?cand:0x7F;} }
+        if (upd) alphaMask[pi]=(redA|grnA)|bluA;
+      }
+    }
+  }
+  function updateContour(x,y) {
+    var yr=(y+0.5)|0;
+    if (yr>=0 && yr<=targetHeight-1) {
+      if (yr!==prevYRounded) {
+        if (prevYRounded!==0x7FFFFFFF){ contour[prevYRounded*2]=leftAtThisY; contour[prevYRounded*2+1]=rightAtThisY; }
+        leftAtThisY=contour[yr*2]; rightAtThisY=contour[yr*2+1]; prevYRounded=yr;
+      }
+      if (x<leftAtThisY)leftAtThisY=x; if (x>rightAtThisY)rightAtThisY=x;
+    }
+  }
+  function updateEdgeCount(x,y) {
+    if (wpMode) return updateEdgeCountWP(x,y);
+    var yt=y|0;
+    if (yt===prevYTruncated) return;
+    if (!(yt>=clipTop-1 && yt<=clipBottom)) return;
+    if (prevYTruncated===0x7FFFFFFF){ prevYTruncated=yt; return; }
+    var pixelY, rInc,gInc,bInc;
+    if (yt>prevYTruncated){ pixelY=yt; rInc=0x010000;gInc=0x0100;bInc=0x01; } else { pixelY=prevYTruncated; rInc=0xFF0000;gInc=0xFF00;bInc=0xFF; }
+    prevYTruncated=yt;
+    var base=pixelY*targetWidth;
+    var rOff=Math.max((x+subPixelDelta+1)|0,clipLeft), gOff=Math.max((x+1)|0,clipLeft), bOff=Math.max((x-subPixelDelta+1)|0,clipLeft);
+    var rIdx=base+rOff, gIdx=base+gOff, bIdx=base+bOff, cw,rc,gc,bc,rest;
+    if (rIdx===bIdx){ if(rOff<=clipRight){ cw=edgeCounts[rIdx]; rc=(cw+rInc)&0xFF0000;gc=(cw+gInc)&0xFF00;bc=(cw+bInc)&0xFF; edgeCounts[rIdx]=(rc|gc)|bc; } }
+    else if (rIdx===gIdx){
+      if(rOff<=clipRight){ cw=edgeCounts[rIdx]; rc=(cw+rInc)&0xFF0000;gc=(cw+gInc)&0xFF00;rest=cw&0xFF; edgeCounts[rIdx]=(rc|gc)|rest; }
+      if(bOff<=clipRight){ cw=edgeCounts[bIdx]; rest=cw&0xFFFF00;bc=(cw+bInc)&0xFF; edgeCounts[bIdx]=rest|bc; }
+    } else {
+      if(rOff<=clipRight){ cw=edgeCounts[rIdx]; rc=(cw+rInc)&0xFF0000;rest=cw&0xFFFF; edgeCounts[rIdx]=rc|rest; }
+      if(bOff<=clipRight){ cw=edgeCounts[bIdx]; rest=cw&0xFF0000;gc=(cw+gInc)&0xFF00;bc=(cw+bInc)&0xFF; edgeCounts[bIdx]=(rest|gc)|bc; }
+    }
+  }
+
+  // ===== blend loops (full-span; honors clippingSpec) =====
+  function clipSpanL(y){ return clippingSpec ? clippingSpec[y*2] : 0; }
+  function clipSpanR(y){ return clippingSpec ? clippingSpec[y*2+1] : targetWidth-1; }
+
+  function blendFillOnly(l,t,r,b) {
+    for (var dY=t; dY<=b; dY++) {
+      var eR=0,eG=0,eB=0, csL=clipSpanL(dY), csR=clipSpanR(dY);
+      var pi=dY*targetWidth+l-1;
+      for (var dX=l; dX<=r; dX++) {
+        pi++;
+        var ew=edgeCounts[pi]; if(ew!==0)edgeCounts[pi]=0;
+        var er=(ew&0xFF0000)>>>16; if(er>127)er-=256;
+        var eg=(ew&0xFF00)>>>8; if(eg>127)eg-=256;
+        var eb=(ew&0xFF); if(eb>127)eb-=256;
+        eR=(eR+er)&0xFF; eG=(eG+eg)&0xFF; eB=(eB+eb)&0xFF;
+        var aw=alphaMask[pi]; if(aw!==0)alphaMask[pi]=0;
+        if (dX<csL||dX>csR) continue;
+        if (aw!==0 || eR!==0 || eG!==0 || eB!==0)
+          blendFillOnlyAt(pi, eR!==0, eG!==0, eB!==0, aw);
+      }
+    }
+  }
+  function blendStrokeAndFill(l,t,r,b) {
+    for (var dY=t; dY<=b; dY++) {
+      var eR=0,eG=0,eB=0, csL=clipSpanL(dY), csR=clipSpanR(dY);
+      var pi=dY*targetWidth+l-1;
+      for (var dX=l; dX<=r; dX++) {
+        pi++;
+        var ew=edgeCounts[pi]; if(ew!==0)edgeCounts[pi]=0;
+        var er=(ew&0xFF0000)>>>16; if(er>127)er-=256;
+        var eg=(ew&0xFF00)>>>8; if(eg>127)eg-=256;
+        var eb=(ew&0xFF); if(eb>127)eb-=256;
+        eR=(eR+er)&0xFF; eG=(eG+eg)&0xFF; eB=(eB+eb)&0xFF;
+        var aw=alphaMask[pi]; if(aw!==0)alphaMask[pi]=0;
+        if (dX<csL||dX>csR) continue;
+        if (aw!==0 || eR!==0 || eG!==0 || eB!==0)
+          blendStrokeAndFillAt(pi, eR!==0, eG!==0, eB!==0, aw);
+      }
+    }
+  }
+  function blendStrokeOnly(l,t,r,b) {
+    for (var dY=t; dY<=b; dY++) {
+      var csL=clipSpanL(dY), csR=clipSpanR(dY), pi=dY*targetWidth+l-1;
+      for (var dX=l; dX<=r; dX++) {
+        pi++;
+        var aw=alphaMask[pi];
+        if (aw!==0){ alphaMask[pi]=0; if(dX>=csL&&dX<=csR) blendStrokeOnlyAt(pi, aw); }
+      }
+    }
+  }
+
+  // ===== per-pixel "over" compositing (v7: no submorph-clip; morphIds = currentMorphId) =====
+  function composite(pi, alphaR,alphaG,alphaB, foreR,foreG,foreB) {
+    if (alphaR+alphaG+alphaB===0.0) return;
+    var tw=targetBits[pi];
+    var aBits=tw&0xFF000000, rBits=tw&0xFF0000, gBits=tw&0xFF00, bBits=tw&0xFF;
+    var tA=(aBits>>>0)*(1.0/(255.0*256*256*256)), un,ra,rc;
+    if (alphaR!==0.0){ un=1.0-alphaR; ra=alphaR+un*tA; rc=alphaR*foreR+(un*(rBits>>>16))*tA; rBits=((rc/ra+0.5)>>>0)<<16; }
+    if (alphaG!==0.0){ un=1.0-alphaG; ra=alphaG+un*tA; rc=alphaG*foreG+(un*(gBits>>>8))*tA; gBits=((rc/ra+0.5)>>>0)<<8; aBits=((ra*255.0+0.5)>>>0)<<24; }
+    if (alphaB!==0.0){ un=1.0-alphaB; ra=alphaB+un*tA; rc=alphaB*foreB+(un*bBits)*tA; bBits=(rc/ra+0.5)>>>0; }
+    targetBits[pi]=(((aBits|rBits)|gBits)|bBits)>>>0;
+    morphIds[pi]=currentMorphId>>>0;
+  }
+  function blendFillOnlyAt(pi, isR,isG,isB, aaw) {
+    var aR=aaw&0x7F0000, aG=aaw&0x7F00, aB=aaw&0x7F;
+    if(isR)aR=0x7F0000-aR; if(isG)aG=0x7F00-aG; if(isB)aB=0x7F-aB;
+    composite(pi, aR*(1.0/8323072.0)*fillA, aG*(1.0/32512.0)*fillA, aB*(1.0/127.0)*fillA, fillR,fillG,fillB);
+  }
+  function blendStrokeAndFillAt(pi, isR,isG,isB, aaw) {
+    var aRA=(aaw&0x7F0000)*(1.0/8323072.0), aGA=(aaw&0x7F00)*(1.0/32512.0), aBA=(aaw&0x7F)*(1.0/127.0);
+    var alphaR,alphaG,alphaB,foreR,foreG,foreB;
+    if(isR){alphaR=aRA*strokeA+(1.0-aRA)*fillA; foreR=aRA*strokeR+(1.0-aRA)*fillR;} else {alphaR=aRA*strokeA; foreR=strokeR;}
+    if(isG){alphaG=aGA*strokeA+(1.0-aGA)*fillA; foreG=aGA*strokeG+(1.0-aGA)*fillG;} else {alphaG=aGA*strokeA; foreG=strokeG;}
+    if(isB){alphaB=aBA*strokeA+(1.0-aBA)*fillA; foreB=aBA*strokeB+(1.0-aBA)*fillB;} else {alphaB=aBA*strokeA; foreB=strokeB;}
+    composite(pi, alphaR,alphaG,alphaB, foreR,foreG,foreB);
+  }
+  function blendStrokeOnlyAt(pi, aaw) {
+    composite(pi, (aaw&0x7F0000)*(1.0/8323072.0)*strokeA, (aaw&0x7F00)*(1.0/32512.0)*strokeA, (aaw&0x7F)*(1.0/127.0)*strokeA, strokeR,strokeG,strokeB);
+  }
+
+  // ===== WholePixel (single 8-bit channel) coverage + blend =====
+  // Optimized path used by Cuis for text/fills: strokeWidth 0, AA 1.6. Processes the 2x2
+  // cell around the pen point (matches C's updateAlphasWPZeroStroke exactly — the earlier
+  // general-bbox approximation lost AA pixels at integer coords, causing crunchy glyphs).
+  function updateAlphasWPZeroStroke(x,y) {
+    var t=y|0, b=t+1, l=x|0, r=l+1;
+    if(t<clipTop)t=clipTop; if(b>clipBottom)b=clipBottom; if(l<clipLeft)l=clipLeft; if(r>clipRight)r=clipRight;
+    for (var dY=t; dY<=b; dY++) {
+      var dy=dY-y, dySq=dy*dy, pi=dY*targetWidth+l-1;
+      for (var dX=l; dX<=r; dX++) {
+        pi++;
+        var dx=dX-x, dist=dx*dx+dySq;
+        if (dist < auxDilHalfSq) {
+          var ab=alphaMaskWP[pi];
+          if (ab !== 0x7F) {
+            var cand=((auxDilHalf-Math.sqrt(dist))*auxAAInv)|0;
+            if (cand>ab) { alphaMaskWP[pi]=cand; affectedBits[pi>>4]=1; }
+          }
+        }
+      }
+    }
+  }
+  function updateAlphasWP(x,y) {
+    if (strokeWidth===0.0 && Math.abs(antiAliasingWidth-1.6)<1e-6) return updateAlphasWPZeroStroke(x,y);
+    if (dashBitLength !== 0.0) {
+      trajectoryLength += hop;
+      var bit = (((trajectoryLength/dashBitLength)|0) + dashBitOffset) % dashBitCount;
+      if (!(dashedStrokeBits & (1 << ((dashBitCount-bit)-1)))) return;
+    }
+    var t=((y-auxDilHalf)+1)|0; if(t<clipTop)t=clipTop;
+    var b=(y+auxDilHalf)|0; if(b>clipBottom)b=clipBottom;
+    var l=((x-auxDilHalf)+1)|0; if(l<clipLeft)l=clipLeft;       // note: no subPixelDelta in WP
+    var r=(x+auxDilHalf)|0; if(r>clipRight)r=clipRight;
+    for (var displayY=t; displayY<=b; displayY++) {
+      var pi=(displayY*targetWidth+l)-1, dy=displayY-y, dySq=dy*dy;
+      for (var displayX=l; displayX<=r; displayX++) {
+        pi++;
+        var dx=displayX-x, dist=dx*dx+dySq;
+        if (dist < auxDilHalfSq) {
+          var ab=alphaMaskWP[pi];
+          if (ab !== 0x7F) {
+            var aux1=auxDilHalf-Math.sqrt(dist);
+            var cand=((aux1<antiAliasingWidth?aux1:antiAliasingWidth)*auxAAInv)|0;
+            if (cand>ab) { alphaMaskWP[pi]=(cand<0x7F?cand:0x7F); affectedBits[pi>>4]=1; }
+          }
+        }
+      }
+    }
+  }
+  function updateEdgeCountWP(x,y) {
+    var yt=y|0;
+    if (yt===prevYTruncated) return;
+    if (!(yt>=clipTop-1 && yt<=clipBottom)) return;
+    if (prevYTruncated===0x7FFFFFFF){ prevYTruncated=yt; return; }
+    var pixelY, inc;
+    if (yt>prevYTruncated){ pixelY=yt; inc=1; } else { pixelY=prevYTruncated; inc=0xFF; }
+    prevYTruncated=yt;
+    var off=Math.max((x+1)|0,clipLeft);
+    if (off<=clipRight){ var pi=pixelY*targetWidth+off; edgeCountsWP[pi]=(edgeCountsWP[pi]+inc)&0xFF; affectedBits[pi>>4]=1; }
+  }
+  function compositeWP(pi, alpha, foreR,foreG,foreB) {
+    if (alpha===0.0) return;
+    var un=1.0-alpha, tw=targetBits[pi], aBits=tw&0xFF000000;
+    var tA=(aBits>>>0)*(1.0/(255.0*256*256*256));
+    var ra=alpha+un*tA;
+    var rB=(((alpha*foreR+(un*((tw&0xFF0000)>>>16))*tA)/ra+0.5)>>>0)<<16;
+    var gB=(((alpha*foreG+(un*((tw&0xFF00)>>>8))*tA)/ra+0.5)>>>0)<<8;
+    var bB=((alpha*foreB+(un*(tw&0xFF))*tA)/ra+0.5)>>>0;
+    var aB2=((ra*255.0+0.5)>>>0)<<24;
+    targetBits[pi]=(((aB2|rB)|gB)|bB)>>>0;
+    morphIds[pi]=currentMorphId>>>0;
+  }
+  function blendFillOnlyWP(l,t,r,b) {
+    var opaque = (targetAssumedOpaque && fillA===1.0)
+      ? ((0xFF000000 | ((((fillR+0.5)|0)>>>0)<<16) | ((((fillG+0.5)|0)>>>0)<<8) | (((fillB+0.5)|0)>>>0))>>>0) : 0;
+    var lastSeg=-1, affected=false;
+    for (var dY=t; dY<=b; dY++) {
+      var csL=0, csR=targetWidth-1, aaL=targetWidth, aaR=targetWidth;
+      if (clippingSpec){ csL=clippingSpec[dY*2]; csR=clippingSpec[dY*2+1]; aaL=(csL>=l?csL:targetWidth); aaR=(csR<=r?csR:targetWidth); }
+      var e=0, pi=dY*targetWidth+l, dX=l;
+      while (dX<=r) {
+        var seg=pi>>4;
+        if (lastSeg!==seg){ affected=affectedBits[seg]===1; lastSeg=seg; if(affected)affectedBits[seg]=0; }
+        var segLen=((seg+1)<<4)-pi;
+        if (affected || e!==0) {
+          var toDo=segLen<(r-dX+1)?segLen:(r-dX+1);
+          for (var k=0;k<toDo;k++){
+            var ab=0;
+            if (affected){ var et=edgeCountsWP[pi]; if(et){edgeCountsWP[pi]=0; e=(e+et)&0xFF;} ab=alphaMaskWP[pi]; if(ab)alphaMaskWP[pi]=0; }
+            if (dX>=csL && dX<=csR){
+              var fA=fillA, opq=opaque;
+              if (dX===aaL||dX===aaR){ fA=fillA*0.25; opq=0; }
+              else if (dX-1===aaL||dX+1===aaR){ fA=fillA*0.75; opq=0; }
+              if (e!==0){
+                if (opq!==0 && ab===0){ targetBits[pi]=opq; morphIds[pi]=currentMorphId>>>0; }
+                else compositeWP(pi, (0x7F-ab)*(1.0/127.0)*fA, fillR,fillG,fillB);
+              } else if (ab!==0) compositeWP(pi, ab*(1.0/127.0)*fA, fillR,fillG,fillB);
+            }
+            dX++; pi++;
+          }
+        } else { dX+=segLen; pi+=segLen; }
+      }
+    }
+  }
+  function blendStrokeAndFillWP(l,t,r,b) {
+    var lastSeg=-1, affected=false;
+    for (var dY=t; dY<=b; dY++) {
+      var csL=clipSpanL(dY), csR=clipSpanR(dY);
+      var e=0, pi=dY*targetWidth+l, dX=l;
+      while (dX<=r) {
+        var seg=pi>>4;
+        if (lastSeg!==seg){ affected=affectedBits[seg]===1; lastSeg=seg; if(affected)affectedBits[seg]=0; }
+        var segLen=((seg+1)<<4)-pi;
+        if (affected || e!==0) {
+          var toDo=segLen<(r-dX+1)?segLen:(r-dX+1);
+          for (var k=0;k<toDo;k++){
+            var ab=0;
+            if (affected){ var et=edgeCountsWP[pi]; if(et){edgeCountsWP[pi]=0; e=(e+et)&0xFF;} ab=alphaMaskWP[pi]; if(ab)alphaMaskWP[pi]=0; }
+            if (dX>=csL && dX<=csR){
+              if (ab!==0){
+                if (ab===0x7F) compositeWP(pi, strokeA, strokeR,strokeG,strokeB);
+                else if (e!==0){ var sa=ab*(1.0/127.0), ua=1.0-sa;
+                  compositeWP(pi, sa*strokeA+ua*fillA, sa*strokeR+ua*fillR, sa*strokeG+ua*fillG, sa*strokeB+ua*fillB); }
+                else compositeWP(pi, ab*(1.0/127.0)*strokeA, strokeR,strokeG,strokeB);
+              } else if (e!==0) compositeWP(pi, fillA, fillR,fillG,fillB);
+            }
+            dX++; pi++;
+          }
+        } else { dX+=segLen; pi+=segLen; }
+      }
+    }
+  }
+  function blendStrokeOnlyWP(l,t,r,b) {
+    var lastSeg=-1, affected=false;
+    for (var dY=t; dY<=b; dY++) {
+      var csL=clipSpanL(dY), csR=clipSpanR(dY);
+      var pi=dY*targetWidth+l, dX=l;
+      while (dX<=r) {
+        var seg=pi>>4;
+        if (lastSeg!==seg){ affected=affectedBits[seg]===1; lastSeg=seg; if(affected)affectedBits[seg]=0; }
+        var segLen=((seg+1)<<4)-pi;
+        if (affected) {
+          var toDo=segLen<(r-dX+1)?segLen:(r-dX+1);
+          for (var k=0;k<toDo;k++){
+            var ab=alphaMaskWP[pi]; if(ab){ alphaMaskWP[pi]=0; if(dX>=csL&&dX<=csR) compositeWP(pi, ab*(1.0/127.0)*strokeA, strokeR,strokeG,strokeB); }
+            dX++; pi++;
+          }
+        } else { dX+=segLen; pi+=segLen; }
+      }
+    }
+  }
+
+  // ===== text: render one glyph's contours at (nextGlyphX,nextGlyphY); returns advanceWidth =====
+  function renderGlyph(contourData, gi, nextGlyphX, nextGlyphY) {
+    var i = gi - 1;
+    var advanceWidth = contourData[i];
+    i += 5;
+    var numContours = contourData[i]|0; i += 1;
+    for (var c=0; c<numContours; c++) {
+      var numBeziers = contourData[i]|0;
+      var ttX = contourData[i+1]+nextGlyphX, ttY = contourData[i+2]+nextGlyphY; i += 3;
+      var startX = ttX*txA11+ttY*txA12+txA13, startY = ttX*txA21+ttY*txA22+txA23;
+      var contourStartX = startX, contourStartY = startY;
+      prevYTruncated = 0x7FFFFFFF;
+      for (var bz=0; bz<numBeziers; bz++) {
+        ttX=contourData[i]; ttY=contourData[i+1];
+        var endX=ttX*txA11+ttY*txA12+startX, endY=ttX*txA21+ttY*txA22+startY;
+        ttX=contourData[i+2]; ttY=contourData[i+3]; i += 4;
+        var ctrlX=ttX*txA11+ttY*txA12+startX, ctrlY=ttX*txA21+ttY*txA22+startY;
+        var xMin=Math.min(startX,endX),xMax=Math.max(startX,endX),yMin=Math.min(startY,endY),yMax=Math.max(startY,endY);
+        spanLeft=Math.min(spanLeft,Math.min(xMin,(xMin+ctrlX)/2.0)); spanRight=Math.max(spanRight,Math.max(xMax,(xMax+ctrlX)/2.0));
+        spanTop=Math.min(spanTop,Math.min(yMin,(yMin+ctrlY)/2.0)); spanBottom=Math.max(spanBottom,Math.max(yMax,(yMax+ctrlY)/2.0));
+        var x=startX,y=startY; updateAlphas(x,y); updateEdgeCount(x,y);
+        var dx=Math.abs(endX-startX),dy=Math.abs(endY-startY);
+        var inc=Math.min(0.5/Math.max(dx,dy),0.5), t=0.0,t0,x0,y0,o,f1,f2,f3,len;
+        do {
+          t0=t;x0=x;y0=y; t=t0+inc;o=1.0-t; f1=o*o;f2=2.0*o*t;f3=t*t;
+          x=f1*startX+f2*ctrlX+f3*endX; y=f1*startY+f2*ctrlY+f3*endY; dx=x-x0;dy=y-y0; len=Math.sqrt(dx*dx+dy*dy);
+          do { inc=inc/len*hop; t=t0+inc;o=1.0-t; f1=o*o;f2=2.0*o*t;f3=t*t;
+            x=f1*startX+f2*ctrlX+f3*endX; y=f1*startY+f2*ctrlY+f3*endY; dx=x-x0;dy=y-y0; len=Math.sqrt(dx*dx+dy*dy);
+          } while (hop/len < 1.0);
+          if (t<1.0){ updateAlphas(x,y); updateEdgeCount(x,y); }
+        } while (t<1.0);
+        updateAlphas(endX,endY); updateEdgeCount(endX,endY);
+        startX=endX; startY=endY;
+      }
+      // close the contour: count the edge crossing back to the contour start (matches C).
+      // Without this, a contour whose last point != first point leaves the winding open,
+      // producing fill notches/leaks on glyphs like "B".
+      updateEdgeCount(contourStartX, contourStartY);
+    }
+    return advanceWidth;
+  }
+  // shared display driver. charAt(i) -> code; lookup maps code -> glyph index (<1 => glyph 1)
+  function displayLoop(len, charAt, contourData, contourDataIndexes, start, stop, destX, destY, sx, sy) {
+    trajectoryLength = 0.0;
+    txA11*=sx; txA12*=sy; txA21*=sx; txA22*=sy;
+    var nextGlyphX = destX/sx, nextGlyphY = destY/sy;
+    for (var k=start-1; k<stop; k++) {
+      var code = charAt(k);
+      var gi = contourDataIndexes[code]; if (gi<1) gi=1;
+      var advanceWidth = renderGlyph(contourData, gi, nextGlyphX, nextGlyphY);
+      nextGlyphX += advanceWidth;
+    }
+    txA11/=sx; txA12/=sy; txA21/=sx; txA22/=sy;
+    return nextGlyphX*sx;
+  }
+
+  // ===== primitive dispatch helpers =====
+  function f(d){ return ip.stackFloatValue(d); }
+  function n(d){ return ip.stackIntegerValue(d); }
+  function w32(d){ var o=ip.stackObjectValue(d); return o.words; }
+  function f32(d){ var o=ip.stackObjectValue(d); return o.wordsAsFloat32Array(); }
+  function i32(d){ var o=ip.stackObjectValue(d); return o.wordsAsInt32Array(); }
+  function bytes(d){ var o=ip.stackObjectValue(d); return o.bytes; }
+  function bool(d){ return ip.booleanValueOf(ip.stackObjectValue(d)); }
+  function self(ac){ ip.pop(ac); return true; }
+  function retInt(ac,v){ ip.popthenPush(ac+1, v|0); return true; }
+  function retFloat(ac,v){ ip.popthenPush(ac+1, ip.floatObjectOf(v)); return true; }
+
+  return {
+    getModuleName: function(){ return "VectorEnginePlugin (SqueakJS v7 port)"; },
+    interpreterProxy: null,
+    setInterpreter: function(anInterpreter){ ip = anInterpreter; this.interpreterProxy = anInterpreter; return true; },
+
+    pluginApiVersion: function(ac){ return retInt(ac, 7); },
+
+    // ---- accessors ----
+    primAntiAliasingWidthsubPixelDelta: function(ac){ antiAliasingWidth=f(1); subPixelDelta=f(0); auxAAInv=127.0/antiAliasingWidth; return self(ac); },
+    primStrokeWidthHop: function(ac){
+      strokeWidth=f(1); hop=f(0);
+      auxDilHalf=(strokeWidth+antiAliasingWidth)*0.5; auxDilHalfSq=auxDilHalf*auxDilHalf;
+      var er=((strokeWidth-antiAliasingWidth)*0.5 - hop) - 2.0; auxErHalfSq=er*Math.abs(er);
+      dashedStrokeBits=0; dashBitLength=0.0; return self(ac);
+    },
+    primStrokeRGBA: function(ac){ strokeR=f(3)*255.0; strokeG=f(2)*255.0; strokeB=f(1)*255.0; strokeA=f(0); return self(ac); },
+    primFillRGBA: function(ac){ fillR=f(3)*255.0; fillG=f(2)*255.0; fillB=f(1)*255.0; fillA=f(0); return self(ac); },
+    primGeometryTxSet: function(ac){ txA11=f(5);txA12=f(4);txA13=f(3);txA21=f(2);txA22=f(1);txA23=f(0); return self(ac); },
+    primClipLeftclipTopclipRightclipBottom: function(ac){ clipLeft=n(3);clipTop=n(2);clipRight=n(1);clipBottom=n(0); return self(ac); },
+    primSetClippingSpec: function(ac){ clippingSpec=i32(0); return self(ac); },
+    primClearClippingSpec: function(ac){ clippingSpec=null; return self(ac); },
+    primCurrentMorphId: function(ac){ currentMorphId=n(0)>>>0; return self(ac); },
+    primTargetAssumedOpaque: function(ac){ targetAssumedOpaque=bool(0)?1:0; return self(ac); },
+    dashedStrokeBitsSet: function(ac){ dashedStrokeBits=n(3); dashBitCount=n(2); dashBitLength=f(1); dashBitOffset=n(0); return self(ac); },
+    primSetTarget: function(ac){
+      wpMode=false;
+      targetBits=w32(7); morphIds=w32(6); edgeCounts=w32(5); alphaMask=w32(4);
+      /* affectedBits = bytes(3) — optimization buffer, unused */ contour=f32(2);
+      targetWidth=n(1); targetHeight=n(0);
+      clippingSpec=null; clipLeft=0; clipTop=0; clipRight=targetWidth-1; clipBottom=targetHeight-1; return self(ac);
+    },
+    primSetTargetWP: function(ac){
+      wpMode=true;
+      targetBits=w32(7); morphIds=w32(6); edgeCountsWP=bytes(5); alphaMaskWP=bytes(4);
+      affectedBits=bytes(3); contour=f32(2);
+      targetWidth=n(1); targetHeight=n(0);
+      clippingSpec=null; clipLeft=0; clipTop=0; clipRight=targetWidth-1; clipBottom=targetHeight-1; return self(ac);
+    },
+    primInitializePath: function(ac){ spanLeft=targetWidth; spanTop=targetHeight; spanRight=0; spanBottom=0; prevYRounded=0x7FFFFFFF; return self(ac); },
+    primNewTrajectoryFragment: function(ac){ prevYTruncated=0x7FFFFFFF; trajectoryLength=0.0; return self(ac); },
+    primResetContour: function(ac){
+      var t=n(1), b=n(0); leftAtThisY=targetWidth; rightAtThisY=0;
+      for (var y=t; y<=b; y++){ contour[y*2]=targetWidth; contour[y*2+1]=0; } return self(ac);
+    },
+    primUpdateContourLastLine: function(ac){ if(prevYRounded!==0x7FFFFFFF){ contour[prevYRounded*2]=leftAtThisY; contour[prevYRounded*2+1]=rightAtThisY; } return self(ac); },
+
+    primSpanLeft:   function(ac){ return retInt(ac, ((spanLeft-auxDilHalf-subPixelDelta)+1)|0); },
+    primSpanRight:  function(ac){ return retInt(ac, (((spanRight+auxDilHalf+subPixelDelta)|0)+1)); },
+    primSpanTop:    function(ac){ return retInt(ac, ((spanTop-auxDilHalf)+1)|0); },
+    primSpanBottom: function(ac){ return retInt(ac, (spanBottom+auxDilHalf)|0); },
+
+    // ---- path ----
+    primLine: function(ac){ pvt_line(f(3),f(2),f(1),f(0)); return self(ac); },
+    primQuadraticBezier: function(ac){ pvt_quad(f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primCubicBezier: function(ac){ pvt_cubic(f(7),f(6),f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primArc: function(ac){ arcImpl(f(7),f(6),f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primPathSequence: function(ac){
+      var a=f32(1), size=n(0), i=0, sX=0,sY=0,eX,eY,c1X,c1Y,c2X,c2Y;
+      while (i<size) {
+        var cmd=a[i]|0; i++;
+        if (cmd===0){ sX=a[i];sY=a[i+1];i+=2; prevYTruncated=0x7FFFFFFF; }
+        else if (cmd===1){ eX=a[i];eY=a[i+1];i+=2; pvt_line(sX,sY,eX,eY); sX=eX;sY=eY; }
+        else if (cmd===2){ eX=a[i];eY=a[i+1];c1X=a[i+2];c1Y=a[i+3];i+=4; pvt_quad(sX,sY,eX,eY,c1X,c1Y); sX=eX;sY=eY; }
+        else if (cmd===3){ eX=a[i];eY=a[i+1];c1X=a[i+2];c1Y=a[i+3];c2X=a[i+4];c2Y=a[i+5];i+=6; pvt_cubic(sX,sY,eX,eY,c1X,c1Y,c2X,c2Y); sX=eX;sY=eY; }
+        else break;
+      }
+      return self(ac);
+    },
+
+    // ---- blend ----
+    primBlendFillOnly: function(ac){ blendFillOnly(n(3),n(2),n(1),n(0)); return self(ac); },
+    primBlendStrokeAndFill: function(ac){ blendStrokeAndFill(n(3),n(2),n(1),n(0)); return self(ac); },
+    primBlendStrokeOnly: function(ac){ blendStrokeOnly(n(3),n(2),n(1),n(0)); return self(ac); },
+
+    // ---- text (9 args: str, from, to, destX, destY, sx, sy, contourData, contourDataIndexes) ----
+    primDisplayByteString: function(ac){
+      var s=bytes(8), from=n(7), to=n(6), destX=f(5), destY=f(4), sx=f(3), sy=f(2), cd=f32(1), cdi=i32(0);
+      return retFloat(ac, displayLoop(s.length, function(k){ return s[k]; }, cd, cdi, from, to, destX, destY, sx, sy));
+    },
+    primDisplayUtf32: function(ac){
+      var s=w32(8), from=n(7), to=n(6), destX=f(5), destY=f(4), sx=f(3), sy=f(2), cd=f32(1), cdi=i32(0);
+      return retFloat(ac, displayLoop(s.length, function(k){ return s[k]; }, cd, cdi, from, to, destX, destY, sx, sy));
+    },
+    primDisplayUtf8: function(ac){
+      // UTF-8 multi-byte handled via the trie: contourDataIndexes[base+byte]; negative => continuation
+      var s=bytes(8), from=n(7), to=n(6), destX=f(5), destY=f(4), sx=f(3), sy=f(2), cd=f32(1), cdi=i32(0);
+      trajectoryLength=0.0; txA11*=sx; txA12*=sy; txA21*=sx; txA22*=sy;
+      var nextGlyphX=destX/sx, nextGlyphY=destY/sy, base=0;
+      for (var k=from-1; k<to; k++){
+        var gi = cdi[base + s[k]];
+        if (gi<0){ base = -gi; continue; }
+        if (gi<1) gi=1;
+        nextGlyphX += renderGlyph(cd, gi, nextGlyphX, nextGlyphY);
+        base=0;
+      }
+      txA11/=sx; txA12/=sy; txA21/=sx; txA22/=sy;
+      return retFloat(ac, nextGlyphX*sx);
+    },
+
+    // ---- WholePixel variants: path/text reuse the same flatteners (dispatch via wpMode);
+    //      only the blend differs (single 8-bit channel) ----
+    primLineWP: function(ac){ pvt_line(f(3),f(2),f(1),f(0)); return self(ac); },
+    primQuadraticBezierWP: function(ac){ pvt_quad(f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primCubicBezierWP: function(ac){ pvt_cubic(f(7),f(6),f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primArcWP: function(ac){ arcImpl(f(7),f(6),f(5),f(4),f(3),f(2),f(1),f(0)); return self(ac); },
+    primPathSequenceWP: function(ac){ return this.primPathSequence(ac); },
+    primBlendFillOnlyWP: function(ac){ blendFillOnlyWP(n(3),n(2),n(1),n(0)); return self(ac); },
+    primBlendStrokeAndFillWP: function(ac){ blendStrokeAndFillWP(n(3),n(2),n(1),n(0)); return self(ac); },
+    primBlendStrokeOnlyWP: function(ac){ blendStrokeOnlyWP(n(3),n(2),n(1),n(0)); return self(ac); },
+    primDisplayByteStringWP: function(ac){ return this.primDisplayByteString(ac); },
+    primDisplayUtf32WP: function(ac){ return this.primDisplayUtf32(ac); },
+    primDisplayUtf8WP: function(ac){ return this.primDisplayUtf8(ac); },
+  };
+}
+
+function registerVectorEnginePlugin() {
+  if (typeof Squeak === "object" && Squeak.registerExternalModule) {
+    Squeak.registerExternalModule('VectorEnginePlugin', VectorEnginePlugin());
+  } else self.setTimeout(registerVectorEnginePlugin, 100);
+}
+registerVectorEnginePlugin();

--- a/squeak.js
+++ b/squeak.js
@@ -75,6 +75,7 @@ import "./plugins/SpeechPlugin.js";
 import "./plugins/SqueakSSL.js";
 import "./plugins/SoundGenerationPlugin.js";
 import "./plugins/StarSqueakPlugin.js";
+import "./plugins/VectorEnginePlugin.js";
 import "./plugins/ZipPlugin.js";
 import "./ffi/libc.js";
 import "./ffi/opengl.js";

--- a/vm.image.js
+++ b/vm.image.js
@@ -228,7 +228,8 @@ Object.subclass('Squeak.Image',
                         format = (formatAndClass >>> 24) & 0x1F,
                         classID = formatAndClass & 0x003FFFFF,
                         hash = sizeAndHash & 0x003FFFFF;
-                    var bits = readBits(size, format < 10 && classID > 0);
+                    // Spur pointer formats are 0-5; format 9 (64-bit) and up are raw, non-pointer bits
+                    var bits = readBits(size, format < 6 && classID > 0);
                     // align on 8 bytes, min size 16 bytes
                     pos += is64Bit
                       ? (size < 1 ? 1 - size : 0) * 8

--- a/vm.object.js
+++ b/vm.object.js
@@ -198,6 +198,9 @@ Object.subclass('Squeak.Object',
     isWords: function() {
         return this._format === 6;
     },
+    isShorts: function() {
+        return false; // pre-Spur images have no dedicated 16-bit format
+    },
     isBytes: function() {
         var fmt = this._format;
         return fmt >= 8 && fmt <= 11;

--- a/vm.object.spur.js
+++ b/vm.object.spur.js
@@ -31,7 +31,10 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
             instSize = instSpec & 0xFFFF,
             format = (instSpec>>16) & 0x1F
         this._format = format;
-        if (format < 12) {
+        if (format === 9) { // 64-bit, stored as 32-bit words (2 words each)
+            if (indexableSize > 0)
+                this.words = new Uint32Array(indexableSize * 2);
+        } else if (format < 12) {
             if (format < 10) {
                 if (instSize + indexableSize > 0)
                     this.pointers = this.fillArray(instSize + indexableSize, nilObj);
@@ -42,6 +45,12 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
                         this.float = 0.0;
                     } else
                         this.words = new Uint32Array(indexableSize);
+        } else if (format < 16) { // 16-bit shorts, stored as 32-bit words (2 shorts each)
+            // normalize to the 32-bit image convention (12 = even, 13 = odd number of shorts)
+            this._format = 12 + (indexableSize & 1);
+            if (indexableSize > 0) {
+                this.words = new Uint32Array((indexableSize + 1) >> 1);
+            }
         } else // Bytes
             if (indexableSize > 0) {
                 // this._format |= -indexableSize & 3;       //deferred to writeTo()
@@ -87,6 +96,12 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
                     this.pointers = this.decodePointers(nWords, oops, oopMap, getCharacter, is64Bit);
                 }
                 break;
+            case 9: // 64 bit array (e.g. Float64Array, DoubleWordArray)
+                // stored as 32-bit words, two per 64-bit element (no padding, 8-byte aligned)
+                if (nWords > 0) {
+                    this.words = this.decodeWords(nWords, bits, littleEndian);
+                }
+                break;
             case 11: // 32 bit array (odd length in 64 bits)
                 nWords--;
                 this._format = 10;
@@ -100,8 +115,18 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
                 }
                 break;
             case 12: // 16 bit array
-            case 13: // 16 bit array (odd length)
-                throw Error("16 bit arrays not supported yet");
+            case 13: // 16 bit array (one 16-bit slot of padding in last word)
+            case 14: // 16 bit array (two 16-bit slots of padding, only in 64 bit images)
+            case 15: // 16 bit array (three 16-bit slots of padding, only in 64 bit images)
+                // the low 2 format bits count unused 16-bit slots in the last allocation unit
+                var numShorts = nWords * 2 - (this._format & 3);
+                nWords = (numShorts + 1) >> 1; // 32-bit words needed to hold the shorts
+                // normalize to the 32-bit image convention (12 = even, 13 = odd number of shorts)
+                this._format = 12 + (numShorts & 1);
+                if (numShorts > 0) {
+                    this.words = this.decodeWords(nWords, bits, littleEndian);
+                }
+                break;
             case 20: // 8 bit array, length-4 (64 bit image)
             case 21: // ... length-5
             case 22: // ... length-6
@@ -301,10 +326,16 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
         if (fmt === 3 && primHandler.vm.isContext(this))
             return this.pointers[Squeak.Context_stackPointer]; // no access beyond top of stacks
         if (fmt < 6) return this.pointersSize() - this.instSize(); // pointers
+        if (fmt === 9) return this.wordsSize() >> 1; // 64-bit: two 32-bit words per element
         if (fmt < 12) return this.wordsSize(); // words
         if (fmt < 16) return this.shortsSize(); // shorts
         if (fmt < 24) return this.bytesSize(); // bytes
         return 4 * this.pointersSize() + this.bytesSize(); // methods
+    },
+    shortsSize: function() {
+        // 16-bit shorts are packed two per 32-bit word; the odd-length format (13)
+        // means the last short slot is unused padding
+        return this.words ? this.words.length * 2 - (this._format & 1) : 0;
     },
     snapshotSize: function() {
         // words of extra object header and body this object would take up in image snapshot
@@ -387,6 +418,10 @@ Squeak.Object.subclass('Squeak.ObjectSpur',
     },
     isWords: function() {
         return this._format === 10;
+    },
+    isShorts: function() {
+        var fmt = this._format;
+        return fmt >= 12 && fmt <= 15;
     },
     isWordsOrBytes: function() {
         var fmt = this._format;

--- a/vm.plugins.file.browser.js
+++ b/vm.plugins.file.browser.js
@@ -45,6 +45,12 @@ Object.extend(Squeak.Primitives.prototype,
         var delimitor = this.emulateMac ? ':' : '/';
         return this.popNandPushIfOK(1, this.charFromInt(delimitor.charCodeAt(0)));
     },
+    primitiveGetWorkingDirectory: function(argCount) {
+        // Newer images (e.g. Cuis 7.9) ask the VM for its working directory during startup;
+        // answer the same path as the VM-path primitive (142) so it stays consistent with our
+        // virtual file system. Failing this primitive aborts startup with "primWorkingDirectory failed".
+        return this.popNandPushIfOK(argCount + 1, this.makeStString(this.filenameToSqueak(Squeak.vmPath)));
+    },
     primitiveDirectoryEntry: function(argCount) {
         var dirNameObj = this.stackNonInteger(1),
             fileNameObj = this.stackNonInteger(0);

--- a/vm.plugins.file.node.js
+++ b/vm.plugins.file.node.js
@@ -62,6 +62,12 @@ Object.extend(Squeak.Primitives.prototype,
         var delimitor = this.emulateMac ? ':' : path.sep;
         return this.popNandPushIfOK(argCount + 1, this.charFromInt(delimitor.charCodeAt(0)));
     },
+    primitiveGetWorkingDirectory: function(argCount) {
+        // Newer images (e.g. Cuis 7.9) ask the VM for its working directory during startup;
+        // answer the same path as the VM-path primitive (142). Failing this primitive aborts
+        // startup with "primWorkingDirectory failed".
+        return this.popNandPushIfOK(argCount + 1, this.makeStString(this.filenameToSqueak(Squeak.vmPath)));
+    },
     primitiveDirectoryLookup: function(argCount) {
         var index = this.stackInteger(0),
             dirNameObj = this.stackNonInteger(1);

--- a/vm.plugins.js
+++ b/vm.plugins.js
@@ -26,7 +26,7 @@ Object.extend(Squeak.Primitives.prototype,
     initPlugins: function() {
         Object.extend(this.builtinModules, {
             JavaScriptPlugin:       this.findPluginFunctions("js_"),
-            FilePlugin:             this.findPluginFunctions("", "primitive(Disable)?(File|Directory)"),
+            FilePlugin:             this.findPluginFunctions("", "primitive((Disable)?(File|Directory)|GetWorkingDirectory)"),
             DropPlugin:             this.findPluginFunctions("", "primitiveDropRequest"),
             SoundPlugin:            this.findPluginFunctions("snd_"),
             JPEGReadWriter2Plugin:  this.findPluginFunctions("jpeg2_"),

--- a/vm.primitives.js
+++ b/vm.primitives.js
@@ -241,6 +241,7 @@ Object.subclass('Squeak.Primitives',
             case 149: return this.primitiveGetAttribute(argCount);
             // File Primitives (150-169)
             case 150: if (this.oldPrims) return this.primitiveFileAtEnd(argCount);
+                else return this.popNandPushFloatIfOK(argCount+1, Math.cos(this.stackFloat(0))); // Float cos (newer images)
             case 151: if (this.oldPrims) return this.primitiveFileClose(argCount);
             case 152: if (this.oldPrims) return this.primitiveFileGetPosition(argCount);
             case 153: if (this.oldPrims) return this.primitiveFileOpen(argCount);
@@ -416,6 +417,14 @@ Object.subclass('Squeak.Primitives',
             case 551: return this.namedPrimitive('ADPCMCodecPlugin', 'primitiveDecodeStereo', argCount);
             case 552: return this.namedPrimitive('ADPCMCodecPlugin', 'primitiveEncodeMono', argCount);
             case 553: return this.namedPrimitive('ADPCMCodecPlugin', 'primitiveEncodeStereo', argCount);
+            // SmallFloat64 math primitives (newer images), mirror of Float prims 54-59 and 150
+            case 554: return this.popNandPushFloatIfOK(argCount+1, this.ldexp(this.stackFloat(1), this.stackFloat(0))); // SmallFloat64 timesTwoPower:
+            case 555: return this.popNandPushFloatIfOK(argCount+1, Math.sqrt(this.stackFloat(0))); // SmallFloat64 sqrt
+            case 556: return this.popNandPushFloatIfOK(argCount+1, Math.sin(this.stackFloat(0))); // SmallFloat64 sin
+            case 557: return this.popNandPushFloatIfOK(argCount+1, Math.atan(this.stackFloat(0))); // SmallFloat64 arcTan
+            case 558: return this.popNandPushFloatIfOK(argCount+1, Math.log(this.stackFloat(0))); // SmallFloat64 ln
+            case 559: return this.popNandPushFloatIfOK(argCount+1, Math.exp(this.stackFloat(0))); // SmallFloat64 exp
+            case 560: return this.popNandPushFloatIfOK(argCount+1, Math.cos(this.stackFloat(0))); // SmallFloat64 cos
             // External primitive support primitives (570-574)
             // case 570: return this.primitiveFlushExternalPrimitives(argCount);
             case 571: return this.primitiveUnloadModule(argCount);
@@ -1040,6 +1049,8 @@ Object.subclass('Squeak.Primitives',
         if (array.isWords()) // words...
             if (info.convertChars) return this.charFromInt(array.words[index-1] & 0x3FFFFFFF);
             else return this.pos32BitIntFor(array.words[index-1]);
+        if (array.isShorts()) // 16-bit shorts (unsigned, always a SmallInteger)
+            return array.wordsAsUint16Array()[index-1];
         if (array.isBytes()) // bytes...
             if (info.convertChars) return this.charFromInt(array.bytes[index-1] & 0xFF);
             else return array.bytes[index-1] & 0xFF;
@@ -1091,6 +1102,14 @@ Object.subclass('Squeak.Primitives',
                 intToPut = this.stackPos32BitInt(0);
             }
             if (this.success) array.words[index-1] = intToPut;
+            return objToPut;
+        }
+        if (array.isShorts()) {  // 16-bit shorts...
+            intToPut = this.stackInteger(0);
+            if (this.success) {
+                if (intToPut < 0 || intToPut > 0xFFFF) {this.success = false; return objToPut;}
+                array.wordsAsUint16Array()[index-1] = intToPut;
+            }
             return objToPut;
         }
         // bytes...


### PR DESCRIPTION
While trying to run recent 64-bit Spur Cuis images (Cuis 7.7 and 7.9) I hit a series of independent issues. Each fix below was needed to get from "won't load" to a fully booting Cuis desktop with a working clock and Transcript.

### Spur 16-bit and 64-bit indexable arrays
`vm.object.spur.js`, `vm.image.js`, `vm.object.js`, `vm.primitives.js`

- Decode **16-bit arrays** (formats 12–15) instead of throwing `16 bit arrays not supported yet`. They're stored as 32-bit words and the format is normalized to the 32-bit-image convention (12 = even, 13 = odd number of shorts).
- Decode **64-bit indexable arrays** (format 9, e.g. `Float64Array`), which previously failed with `Unknown object format: 9`.
- Fix the Spur object reader: only formats **0–5** are pointer objects (it was `format < 10`), so format-9 contents are read as raw words rather than oops (this was the actual cause of the `Float64Array` `DataView` crash).
- Allocate the correct backing store for newly created 16-bit/64-bit indexable instances in `initInstanceOf`.
- Add `shortsSize`/`isShorts` (the former was already referenced but undefined) and a 16-bit branch to the generic `at:`/`at:put:` primitives.

### JIT: emit a label after the `nop` bytecode
`jit.js`

The Sista `nop` (`0x5F`) was the only bytecode that consumed a byte without calling `generateLabel`, so any jump target immediately following a `nop` got no `case` label. At runtime this hit the single-step fallback and threw `invalid PC` (e.g. `FileIOAccessor>>/` in Cuis, which has a `nop` right before a `jumpIfFalse:` target).

### Float primitives for newer images
`vm.primitives.js`

Implement `Float>>cos` (primitive **150**) and the `SmallFloat64` math primitives **554–560** (`timesTwoPower:`, `sqrt`, `sin`, `arcTan`, `ln`, `exp`, `cos`), mirroring the existing `BoxedFloat64` primitives. `cos` never had an old primitive number, so newer images assign it 150/560.

### FilePlugin: `primitiveGetWorkingDirectory`
`vm.plugins.file.browser.js`, `vm.plugins.file.node.js`, `vm.plugins.js`

Cuis 7.9 calls `FilePlugin>>primitiveGetWorkingDirectory` during startup (`openSourcesAndChanges`). Without it the primitive failed with `primWorkingDirectory failed`, which on the Morphic UI process cascaded into an unrecoverable error loop (and the emergency evaluator in the browser). The `FilePlugin` module matcher in `vm.plugins.js` is also broadened so the new primitive is actually registered (the previous `primitive(Disable)?(File|Directory)` pattern excluded `primitiveGetWorkingDirectory`).

### Testing
- Cuis 7.7 and Cuis 7.9 both boot to a usable desktop (verified in-browser and headless via `squeak_node.js`).
- The existing bundled `headless.image` and the 32-bit demo image still load and run (no regressions).

cc @jvuletich